### PR TITLE
refactor: use env-based API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ SEARCH_SERVICE_URL=http://localhost:8000
 QUEUE_SERVICE_URL=http://localhost:5001
 RAG_SERVICE_URL=http://localhost:8000
 
+# Base URL for semantic search service
+API_BASE_URL=http://localhost:8000
+
 # OpenAI
 OPENAI_API_KEY=your-openai-api-key
 
@@ -93,6 +96,13 @@ SECRET_KEY=your-secret-key-here
 
 # CORS
 CORS_ORIGINS=http://localhost:3000,http://localhost:3001
+```
+
+Create a `.env` file in the frontend directory:
+
+```env
+# Base URL for API requests
+VITE_API_URL=http://localhost:5001
 ```
 
 ## Testing

--- a/backend/routes/semanticSearch.js
+++ b/backend/routes/semanticSearch.js
@@ -2,14 +2,17 @@ const express = require('express');
 const axios = require('axios');
 const router = express.Router();
 
+const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:8000';
+
 router.post('/api/semantic-search', async (req, res) => {
   try {
     const { query, top_k } = req.body;
-    const response = await axios.post('http://localhost:8000/search', { query, top_k });
+    const url = new URL('/search', API_BASE_URL).toString();
+    const response = await axios.post(url, { query, top_k });
     res.json(response.data);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
 });
 
-module.exports = router; 
+module.exports = router;

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -2,6 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Users, CheckCircle, RefreshCw, Shield, Heart, FileText, Globe } from 'lucide-react';
 
+const API_BASE_URL =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_URL) ||
+  process.env.REACT_APP_API_URL ||
+  'http://localhost:5001';
+
 const AdminDashboard = () => {
   const { language, toggleLanguage } = useLanguage();
   const [queue, setQueue] = useState([]);
@@ -16,7 +21,7 @@ const AdminDashboard = () => {
 
   const fetchQueue = async () => {
     try {
-      const response = await fetch('http://localhost:5001/api/queue');
+      const response = await fetch(`${API_BASE_URL}/api/queue`);
       if (response.ok) {
         const data = await response.json();
         setQueue(data.queue);
@@ -31,7 +36,7 @@ const AdminDashboard = () => {
 
   const callNext = async () => {
     try {
-      const response = await fetch('http://localhost:5001/api/call-next', {
+      const response = await fetch(`${API_BASE_URL}/api/call-next`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -47,7 +52,7 @@ const AdminDashboard = () => {
 
   const completeCase = async (queueNumber) => {
     try {
-      const response = await fetch('http://localhost:5001/api/complete-case', {
+      const response = await fetch(`${API_BASE_URL}/api/complete-case`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/pages/UserKiosk.jsx
+++ b/frontend/src/pages/UserKiosk.jsx
@@ -13,6 +13,11 @@ import {
   FileText as FileTextIcon
 } from 'lucide-react';
 
+const API_BASE_URL =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_URL) ||
+  process.env.REACT_APP_API_URL ||
+  'http://localhost:5001';
+
 const UserKiosk = () => {
   const { language, toggleLanguage } = useLanguage();
   const navigate = useNavigate();
@@ -85,7 +90,7 @@ const UserKiosk = () => {
       }
 
       // For other cases, use the existing queue system
-      const response = await fetch('http://localhost:5001/api/generate-queue', {
+      const response = await fetch(`${API_BASE_URL}/api/generate-queue`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -310,4 +315,4 @@ const UserKiosk = () => {
   );
 };
 
-export default UserKiosk; 
+export default UserKiosk;


### PR DESCRIPTION
## Summary
- replace hard-coded semantic search URL with `API_BASE_URL`
- use `VITE_API_URL` for frontend fetch calls
- document required API base URLs

## Testing
- `npm test` (backend) *(fails: ImportError: Config not found in app)*
- `npm test -- --watchAll=false` (frontend) *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_b_689baa1b25b083338aedb98d85da383a