### PR TITLE
Add queue summary email service and admin waiting case view

### DIFF
--- a/backend/utils/llm_service.py
+++ b/backend/utils/llm_service.py
@@ -5,7 +5,8 @@ from typing import List, Dict, Any, Optional
 
 class LLMService:
     def __init__(self, api_key: Optional[str] = None):
-        self.client = OpenAI(api_key=api_key or os.getenv('OPENAI_API_KEY'))
+        api_key = api_key or os.getenv('OPENAI_API_KEY')
+        self.client = OpenAI(api_key=api_key) if api_key else None
         
     def analyze_progress(self, flow_data: Dict, user_progress: List[Dict], case_type: str, language: str = 'en') -> Dict[str, Any]:
         """

--- a/frontend/src/components/EnhancedKioskInterface.jsx
+++ b/frontend/src/components/EnhancedKioskInterface.jsx
@@ -291,7 +291,8 @@ const EnhancedKioskInterface = () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           queue_number: queueNumber,
-          progress: flowProgress
+          progress: flowProgress,
+          send_email: true
         })
       });
       


### PR DESCRIPTION
## Summary
- add summary email utility and queue finalization endpoint that stores summaries and emails users
- support missing OpenAI key by guarding LLM client creation
- expose waiting cases and summaries in facilitator dashboard and trigger email from kiosk interface

## Testing
- `pytest`
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_b_68a7769dae648333b2915ddefc670cfc