### PR TITLE
Improve API base URL handling for email requests

### DIFF
--- a/court-kiosk/frontend/src/components/CompletionPage.jsx
+++ b/court-kiosk/frontend/src/components/CompletionPage.jsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
 import { addToQueue } from '../utils/queueAPI';
+import { getApiBaseUrl } from '../utils/apiConfig';
+
+const API_BASE_URL = getApiBaseUrl();
 
 const CompletionPage = ({ answers, history, flow, onBack, onHome }) => {
   const [selectedOption, setSelectedOption] = useState('');
@@ -109,7 +112,7 @@ const CompletionPage = ({ answers, history, flow, onBack, onHome }) => {
     setIsSubmitting(true);
     try {
       // Send case summary email using the new endpoint
-      const response = await fetch('http://localhost:1904/api/email/send-case-summary', {
+      const response = await fetch(`${API_BASE_URL}/api/email/send-case-summary`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/court-kiosk/frontend/src/utils/apiConfig.js
+++ b/court-kiosk/frontend/src/utils/apiConfig.js
@@ -1,0 +1,23 @@
+const stripTrailingSlash = (url) => url.replace(/\/+$/, '');
+
+export const getApiBaseUrl = () => {
+  const envUrl = process.env.REACT_APP_API_URL;
+  if (envUrl) {
+    return stripTrailingSlash(envUrl);
+  }
+
+  if (typeof window !== 'undefined') {
+    const { protocol, hostname, port } = window.location;
+
+    if (['localhost', '127.0.0.1', '::1', '[::1]'].includes(hostname)) {
+      return 'http://localhost:1904';
+    }
+
+    const portSegment = port ? `:${port}` : '';
+    return `${protocol}//${hostname}${portSegment}`;
+  }
+
+  return 'http://localhost:1904';
+};
+
+export default getApiBaseUrl;

--- a/court-kiosk/frontend/src/utils/queueAPI.js
+++ b/court-kiosk/frontend/src/utils/queueAPI.js
@@ -1,5 +1,7 @@
+import { getApiBaseUrl } from './apiConfig';
+
 // Queue API utility for connecting with enhanced backend
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:1904';
+const API_BASE_URL = getApiBaseUrl();
 
 // Configuration constants
 const CONFIG = {


### PR DESCRIPTION
## Summary
- centralize API base URL detection for the frontend so deployments outside localhost fall back to the current origin
- update queue utilities and completion page email submission to use the shared API base helper instead of hardcoded localhost

## Testing
- npm test -- --watchAll=false *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68d4691ffa188333942d080f5a12d2ef