### PR TITLE
feat: enhance multilingual kiosk experience

### DIFF
--- a/court-kiosk/frontend/src/components/AttorneyDashboard.jsx
+++ b/court-kiosk/frontend/src/components/AttorneyDashboard.jsx
@@ -10,7 +10,6 @@ import {
   FileText, 
   Shield, 
   Heart, 
-  Globe,
   ArrowRight,
   RefreshCw,
   Send,
@@ -27,9 +26,10 @@ import ModernCard from './ModernCard';
 import ModernButton from './ModernButton';
 import './ModernCard.css';
 import './ModernButton.css';
+import LanguageSelector from '../components/LanguageSelector';
 
 const AttorneyDashboard = () => {
-  const { language, toggleLanguage } = useLanguage();
+  const { language } = useLanguage();
   const [queue, setQueue] = useState([]);
   const [currentNumber, setCurrentNumber] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -179,9 +179,9 @@ const AttorneyDashboard = () => {
       
       if (result.success) {
         setError(null);
-        alert(language === 'en' 
-          ? `Email sent successfully to ${caseItem.user_email}` 
-          : `Correo enviado exitosamente a ${caseItem.user_email}`);
+        alert(language === 'es' 
+          ? `Correo enviado exitosamente a ${caseItem.user_email}` 
+          : `Email sent successfully to ${caseItem.user_email}`);
       } else {
         setError(result.error || 'Failed to send email');
       }
@@ -289,7 +289,7 @@ const AttorneyDashboard = () => {
         <ModernCard variant="elevated" className="text-center">
           <RefreshCw className="w-12 h-12 text-blue-600 mx-auto mb-4 animate-spin" />
           <p className="text-gray-600 font-medium">
-            {language === 'en' ? 'Loading queue...' : 'Cargando cola...'}
+            {language === 'es' ? 'Cargando cola...' : 'Loading queue...'}
           </p>
         </ModernCard>
       </div>
@@ -304,30 +304,24 @@ const AttorneyDashboard = () => {
           <div className="flex justify-between items-center">
             <div>
               <h1 className="text-3xl font-bold text-gray-900">
-                {language === 'en' ? 'Attorney Dashboard' : 'Panel del Abogado'}
+                {language === 'es' ? 'Panel del Abogado' : 'Attorney Dashboard'}
               </h1>
               <p className="text-gray-600 mt-1">
-                {language === 'en' 
-                  ? 'Quick case summaries and efficient client assistance'
-                  : 'Resúmenes rápidos de casos y asistencia eficiente al cliente'
+                {language === 'es' 
+                  ? 'Resúmenes rápidos de casos y asistencia eficiente al cliente'
+                  : 'Quick case summaries and efficient client assistance'
                 }
               </p>
             </div>
             <div className="flex items-center space-x-4">
-              <button
-                onClick={toggleLanguage}
-                className="inline-flex items-center space-x-2 px-4 py-2 rounded-lg bg-gray-100 hover:bg-gray-200 transition-colors"
-              >
-                <Globe className="w-4 h-4" />
-                <span>{language === 'en' ? 'Español' : 'English'}</span>
-              </button>
+              <LanguageSelector size="sm" />
               <ModernButton
                 variant="primary"
                 size="medium"
                 onClick={fetchQueue}
                 icon={<RefreshCw className="w-4 h-4" />}
               >
-                {language === 'en' ? 'Refresh' : 'Actualizar'}
+                {language === 'es' ? 'Actualizar' : 'Refresh'}
               </ModernButton>
             </div>
           </div>
@@ -342,24 +336,24 @@ const AttorneyDashboard = () => {
               {/* Queue Stats */}
               <ModernCard variant="elevated">
                 <h2 className="text-xl font-bold text-gray-900 mb-4">
-                  {language === 'en' ? 'Queue Status' : 'Estado de la Cola'}
+                  {language === 'es' ? 'Estado de la Cola' : 'Queue Status'}
                 </h2>
                 <div className="space-y-4">
                   <div className="flex justify-between items-center">
                     <span className="text-gray-600">
-                      {language === 'en' ? 'Waiting' : 'Esperando'}
+                      {language === 'es' ? 'Esperando' : 'Waiting'}
                     </span>
                     <span className="text-2xl font-bold text-blue-600">{waitingCount}</span>
                   </div>
                   <div className="flex justify-between items-center">
                     <span className="text-gray-600">
-                      {language === 'en' ? 'In Progress' : 'En Progreso'}
+                      {language === 'es' ? 'En Progreso' : 'In Progress'}
                     </span>
                     <span className="text-2xl font-bold text-green-600">{inProgressCount}</span>
                   </div>
                   <div className="flex justify-between items-center">
                     <span className="text-gray-600">
-                      {language === 'en' ? 'Current Number' : 'Número Actual'}
+                      {language === 'es' ? 'Número Actual' : 'Current Number'}
                     </span>
                     <span className="text-2xl font-bold text-gray-900">
                       {currentNumber || '--'}
@@ -374,7 +368,7 @@ const AttorneyDashboard = () => {
                     onClick={handleCallNext}
                     icon={<UserCheck className="w-5 h-5" />}
                   >
-                    {language === 'en' ? 'Call Next' : 'Llamar Siguiente'}
+                    {language === 'es' ? 'Llamar Siguiente' : 'Call Next'}
                   </ModernButton>
                 </div>
               </ModernCard>
@@ -382,7 +376,7 @@ const AttorneyDashboard = () => {
               {/* Queue List */}
               <ModernCard variant="elevated">
                 <h2 className="text-xl font-bold text-gray-900 mb-4">
-                  {language === 'en' ? 'Waiting Queue' : 'Cola de Espera'}
+                  {language === 'es' ? 'Cola de Espera' : 'Waiting Queue'}
                 </h2>
                 <div className="space-y-3 max-h-96 overflow-y-auto">
                   {sortedQueue.filter(item => item.status === 'waiting').map((item, index) => {
@@ -414,7 +408,7 @@ const AttorneyDashboard = () => {
                               {item.waitTimeFormatted}
                             </div>
                             <div className="text-xs text-gray-500">
-                              {language === 'en' ? 'waiting' : 'esperando'}
+                              {language === 'es' ? 'esperando' : 'waiting'}
                             </div>
                           </div>
                         </div>
@@ -426,7 +420,7 @@ const AttorneyDashboard = () => {
                   })}
                   {sortedQueue.filter(item => item.status === 'waiting').length === 0 && (
                     <div className="text-center text-gray-500 py-8">
-                      {language === 'en' ? 'No cases waiting' : 'No hay casos esperando'}
+                      {language === 'es' ? 'No hay casos esperando' : 'No cases waiting'}
                     </div>
                   )}
                 </div>
@@ -463,7 +457,7 @@ const AttorneyDashboard = () => {
                         loading={sendingEmail}
                         icon={<Send className="w-4 h-4" />}
                       >
-                        {language === 'en' ? 'Send Email' : 'Enviar Email'}
+                        {language === 'es' ? 'Enviar Email' : 'Send Email'}
                       </ModernButton>
                       <ModernButton
                         variant="success"
@@ -471,7 +465,7 @@ const AttorneyDashboard = () => {
                         onClick={() => handleCompleteCase(selectedCase.queue_number)}
                         icon={<CheckCircle className="w-4 h-4" />}
                       >
-                        {language === 'en' ? 'Complete' : 'Completar'}
+                        {language === 'es' ? 'Completar' : 'Complete'}
                       </ModernButton>
                     </div>
                   </div>
@@ -480,7 +474,7 @@ const AttorneyDashboard = () => {
                 {/* Client Information */}
                 <ModernCard variant="outlined">
                   <h3 className="text-lg font-bold text-gray-900 mb-4">
-                    {language === 'en' ? 'Client Information' : 'Información del Cliente'}
+                    {language === 'es' ? 'Información del Cliente' : 'Client Information'}
                   </h3>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="flex items-center space-x-3">
@@ -490,7 +484,7 @@ const AttorneyDashboard = () => {
                           {selectedCase.user_name || 'Not provided'}
                         </div>
                         <div className="text-sm text-gray-600">
-                          {language === 'en' ? 'Name' : 'Nombre'}
+                          {language === 'es' ? 'Nombre' : 'Name'}
                         </div>
                       </div>
                     </div>
@@ -501,7 +495,7 @@ const AttorneyDashboard = () => {
                           {selectedCase.user_email || 'Not provided'}
                         </div>
                         <div className="text-sm text-gray-600">
-                          {language === 'en' ? 'Email' : 'Correo'}
+                          {language === 'es' ? 'Correo' : 'Email'}
                         </div>
                       </div>
                     </div>
@@ -512,7 +506,7 @@ const AttorneyDashboard = () => {
                           {selectedCase.phone_number || 'Not provided'}
                         </div>
                         <div className="text-sm text-gray-600">
-                          {language === 'en' ? 'Phone' : 'Teléfono'}
+                          {language === 'es' ? 'Teléfono' : 'Phone'}
                         </div>
                       </div>
                     </div>
@@ -523,7 +517,7 @@ const AttorneyDashboard = () => {
                           {selectedCase.waitTimeFormatted}
                         </div>
                         <div className="text-sm text-gray-600">
-                          {language === 'en' ? 'Wait Time' : 'Tiempo de Espera'}
+                          {language === 'es' ? 'Tiempo de Espera' : 'Wait Time'}
                         </div>
                       </div>
                     </div>
@@ -535,7 +529,7 @@ const AttorneyDashboard = () => {
                   <div className="flex items-center justify-between mb-4">
                     <h3 className="text-lg font-bold text-gray-900 flex items-center">
                       <Brain className="w-5 h-5 mr-2 text-blue-600" />
-                      {language === 'en' ? 'AI-Powered Case Analysis' : 'Análisis del Caso con IA'}
+                      {language === 'es' ? 'Análisis del Caso con IA' : 'AI-Powered Case Analysis'}
                     </h3>
                     {analyzing && (
                       <div className="flex items-center text-blue-600">
@@ -551,7 +545,7 @@ const AttorneyDashboard = () => {
                       <div className="bg-white rounded-lg p-4 border border-blue-200">
                         <h4 className="font-semibold text-gray-900 mb-2 flex items-center">
                           <Eye className="w-4 h-4 mr-2 text-blue-600" />
-                          {language === 'en' ? 'Case Overview' : 'Resumen del Caso'}
+                          {language === 'es' ? 'Resumen del Caso' : 'Case Overview'}
                         </h4>
                         <p className="text-gray-700 leading-relaxed">
                           {caseAnalysis.case_overview}
@@ -573,7 +567,7 @@ const AttorneyDashboard = () => {
                         <div className="bg-red-50 rounded-lg p-4 border border-red-200">
                           <h4 className="font-semibold text-red-900 mb-2 flex items-center">
                             <AlertCircle className="w-4 h-4 mr-2 text-red-600" />
-                            {language === 'en' ? 'Immediate Concerns' : 'Preocupaciones Inmediatas'}
+                            {language === 'es' ? 'Preocupaciones Inmediatas' : 'Immediate Concerns'}
                           </h4>
                           <ul className="space-y-1">
                             {caseAnalysis.immediate_concerns.map((concern, index) => (
@@ -590,7 +584,7 @@ const AttorneyDashboard = () => {
                       <div className="bg-white rounded-lg p-4 border border-green-200">
                         <h4 className="font-semibold text-gray-900 mb-3 flex items-center">
                           <FileText className="w-4 h-4 mr-2 text-green-600" />
-                          {language === 'en' ? 'Required Documents' : 'Documentos Requeridos'}
+                          {language === 'es' ? 'Documentos Requeridos' : 'Required Documents'}
                         </h4>
                         <div className="space-y-2">
                           {caseAnalysis.required_documents.map((doc, index) => (
@@ -620,7 +614,7 @@ const AttorneyDashboard = () => {
                       <div className="bg-white rounded-lg p-4 border border-purple-200">
                         <h4 className="font-semibold text-gray-900 mb-3 flex items-center">
                           <ArrowRight className="w-4 h-4 mr-2 text-purple-600" />
-                          {language === 'en' ? 'Next Steps' : 'Próximos Pasos'}
+                          {language === 'es' ? 'Próximos Pasos' : 'Next Steps'}
                         </h4>
                         <div className="space-y-3">
                           {caseAnalysis.next_steps.map((step, index) => (
@@ -646,7 +640,7 @@ const AttorneyDashboard = () => {
                       <div className="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-lg p-4 border border-blue-200">
                         <h4 className="font-semibold text-gray-900 mb-3 flex items-center">
                           <UserCheck className="w-4 h-4 mr-2 text-blue-600" />
-                          {language === 'en' ? 'Your Action Items' : 'Sus Tareas'}
+                          {language === 'es' ? 'Sus Tareas' : 'Your Action Items'}
                         </h4>
                         <ul className="space-y-2">
                           {caseAnalysis.attorney_actions.map((action, index) => (
@@ -662,7 +656,7 @@ const AttorneyDashboard = () => {
                       <div className="bg-white rounded-lg p-4 border border-orange-200">
                         <h4 className="font-semibold text-gray-900 mb-3 flex items-center">
                           <Calendar className="w-4 h-4 mr-2 text-orange-600" />
-                          {language === 'en' ? 'Important Timeline' : 'Cronograma Importante'}
+                          {language === 'es' ? 'Cronograma Importante' : 'Important Timeline'}
                         </h4>
                         <div className="space-y-2">
                           {caseAnalysis.timeline.map((item, index) => (
@@ -684,7 +678,7 @@ const AttorneyDashboard = () => {
                       <div className="bg-green-50 rounded-lg p-4 border border-green-200">
                         <h4 className="font-semibold text-gray-900 mb-3 flex items-center">
                           <Shield className="w-4 h-4 mr-2 text-green-600" />
-                          {language === 'en' ? 'Client Support Tips' : 'Consejos de Apoyo al Cliente'}
+                          {language === 'es' ? 'Consejos de Apoyo al Cliente' : 'Client Support Tips'}
                         </h4>
                         <ul className="space-y-2">
                           {caseAnalysis.client_support.map((tip, index) => (
@@ -700,9 +694,9 @@ const AttorneyDashboard = () => {
                     <div className="text-center py-8">
                       <RefreshCw className="w-12 h-12 text-blue-400 mx-auto mb-4 animate-spin" />
                       <p className="text-gray-600">
-                        {language === 'en' 
-                          ? 'Generating comprehensive case analysis...'
-                          : 'Generando análisis completo del caso...'
+                        {language === 'es' 
+                          ? 'Generando análisis completo del caso...'
+                          : 'Generating comprehensive case analysis...'
                         }
                       </p>
                     </div>
@@ -710,9 +704,9 @@ const AttorneyDashboard = () => {
                     <div className="text-center py-8">
                       <Brain className="w-12 h-12 text-gray-400 mx-auto mb-4" />
                       <p className="text-gray-600">
-                        {language === 'en' 
-                          ? 'Click on a case to generate AI-powered analysis and guidance'
-                          : 'Haga clic en un caso para generar análisis y orientación con IA'
+                        {language === 'es' 
+                          ? 'Haga clic en un caso para generar análisis y orientación con IA'
+                          : 'Click on a case to generate AI-powered analysis and guidance'
                         }
                       </p>
                     </div>
@@ -723,13 +717,13 @@ const AttorneyDashboard = () => {
                 {(selectedCase.documents_needed?.length > 0 || selectedCase.next_steps?.length > 0) && (
                   <ModernCard variant="outlined">
                     <h3 className="text-lg font-bold text-gray-900 mb-4">
-                      {language === 'en' ? 'Forms & Next Steps' : 'Formularios y Próximos Pasos'}
+                      {language === 'es' ? 'Formularios y Próximos Pasos' : 'Forms & Next Steps'}
                     </h3>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                       {selectedCase.documents_needed?.length > 0 && (
                         <div>
                           <h4 className="font-semibold text-gray-900 mb-2">
-                            {language === 'en' ? 'Required Forms:' : 'Formularios Requeridos:'}
+                            {language === 'es' ? 'Formularios Requeridos:' : 'Required Forms:'}
                           </h4>
                           <ul className="space-y-1">
                             {selectedCase.documents_needed.map((form, index) => (
@@ -744,7 +738,7 @@ const AttorneyDashboard = () => {
                       {selectedCase.next_steps?.length > 0 && (
                         <div>
                           <h4 className="font-semibold text-gray-900 mb-2">
-                            {language === 'en' ? 'Next Steps:' : 'Próximos Pasos:'}
+                            {language === 'es' ? 'Próximos Pasos:' : 'Next Steps:'}
                           </h4>
                           <ul className="space-y-1">
                             {selectedCase.next_steps.map((step, index) => (
@@ -764,12 +758,12 @@ const AttorneyDashboard = () => {
               <ModernCard variant="elevated" className="text-center py-16">
                 <Users className="w-16 h-16 text-gray-400 mx-auto mb-4" />
                 <h3 className="text-xl font-bold text-gray-900 mb-2">
-                  {language === 'en' ? 'Select a Case' : 'Seleccione un Caso'}
+                  {language === 'es' ? 'Seleccione un Caso' : 'Select a Case'}
                 </h3>
                 <p className="text-gray-600">
-                  {language === 'en' 
-                    ? 'Click on a case from the queue to view details and provide assistance'
-                    : 'Haga clic en un caso de la cola para ver detalles y proporcionar asistencia'
+                  {language === 'es' 
+                    ? 'Haga clic en un caso de la cola para ver detalles y proporcionar asistencia'
+                    : 'Click on a case from the queue to view details and provide assistance'
                   }
                 </p>
               </ModernCard>

--- a/court-kiosk/frontend/src/components/LanguageSelector.jsx
+++ b/court-kiosk/frontend/src/components/LanguageSelector.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Globe } from 'lucide-react';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const LanguageSelector = ({ className = '', size = 'md' }) => {
+  const { language, setLanguage, availableLanguages, t } = useLanguage();
+
+  const sizeClasses = {
+    sm: 'text-xs px-2 py-1',
+    md: 'text-sm px-3 py-1.5',
+    lg: 'text-base px-4 py-2'
+  };
+
+  return (
+    <label className={`inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white shadow-sm px-2 ${className}`}>
+      <Globe className="w-4 h-4 text-blue-600" aria-hidden />
+      <span className="sr-only">{t('common.languageSelectorAriaLabel')}</span>
+      <select
+        value={language}
+        onChange={(event) => setLanguage(event.target.value)}
+        className={`bg-transparent focus:outline-none focus:ring-0 text-gray-700 font-medium ${sizeClasses[size] || sizeClasses.md}`}
+        aria-label={t('common.languageSelectorLabel')}
+      >
+        {availableLanguages.map(({ code, label }) => (
+          <option key={code} value={code} className="text-gray-900">
+            {label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+};
+
+export default LanguageSelector;

--- a/court-kiosk/frontend/src/components/LoginForm.jsx
+++ b/court-kiosk/frontend/src/components/LoginForm.jsx
@@ -5,6 +5,7 @@ import { Lock, User, Eye, EyeOff, AlertCircle } from 'lucide-react';
 
 const LoginForm = ({ onLoginSuccess }) => {
   const { language } = useLanguage();
+  const isSpanish = language === 'es';
   const { login } = useAuth();
   const [formData, setFormData] = useState({
     username: '',
@@ -45,12 +46,12 @@ const LoginForm = ({ onLoginSuccess }) => {
             <Lock className="h-6 w-6 text-blue-600" />
           </div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            {language === 'en' ? 'Admin Login' : 'Inicio de Sesión de Administrador'}
+            {isSpanish ? 'Inicio de Sesión de Administrador' : 'Admin Login'}
           </h2>
           <p className="mt-2 text-center text-sm text-gray-600">
-            {language === 'en' 
-              ? 'Sign in to access the court kiosk admin dashboard'
-              : 'Inicia sesión para acceder al panel de administración del kiosco judicial'
+            {isSpanish
+              ? 'Inicia sesión para acceder al panel de administración del kiosco judicial'
+              : 'Sign in to access the court kiosk admin dashboard'
             }
           </p>
         </div>
@@ -70,7 +71,7 @@ const LoginForm = ({ onLoginSuccess }) => {
           <div className="space-y-4">
             <div>
               <label htmlFor="username" className="block text-sm font-medium text-gray-700">
-                {language === 'en' ? 'Username' : 'Nombre de Usuario'}
+                {isSpanish ? 'Nombre de Usuario' : 'Username'}
               </label>
               <div className="mt-1 relative">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -84,14 +85,14 @@ const LoginForm = ({ onLoginSuccess }) => {
                   value={formData.username}
                   onChange={handleChange}
                   className="appearance-none relative block w-full pl-10 pr-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
-                  placeholder={language === 'en' ? 'Enter your username' : 'Ingresa tu nombre de usuario'}
+                  placeholder={isSpanish ? 'Ingresa tu nombre de usuario' : 'Enter your username'}
                 />
               </div>
             </div>
             
             <div>
               <label htmlFor="password" className="block text-sm font-medium text-gray-700">
-                {language === 'en' ? 'Password' : 'Contraseña'}
+                {isSpanish ? 'Contraseña' : 'Password'}
               </label>
               <div className="mt-1 relative">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -105,7 +106,7 @@ const LoginForm = ({ onLoginSuccess }) => {
                   value={formData.password}
                   onChange={handleChange}
                   className="appearance-none relative block w-full pl-10 pr-10 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
-                  placeholder={language === 'en' ? 'Enter your password' : 'Ingresa tu contraseña'}
+                  placeholder={isSpanish ? 'Ingresa tu contraseña' : 'Enter your password'}
                 />
                 <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
                   <button
@@ -133,20 +134,20 @@ const LoginForm = ({ onLoginSuccess }) => {
               {loading ? (
                 <div className="flex items-center">
                   <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                  {language === 'en' ? 'Signing in...' : 'Iniciando sesión...'}
+                  {isSpanish ? 'Iniciando sesión...' : 'Signing in...'}
                 </div>
               ) : (
-                language === 'en' ? 'Sign In' : 'Iniciar Sesión'
+                isSpanish ? 'Iniciar Sesión' : 'Sign In'
               )}
             </button>
           </div>
 
           <div className="text-center">
             <div className="text-sm text-gray-600">
-              {language === 'en' ? 'Default credentials:' : 'Credenciales por defecto:'}
+              {isSpanish ? 'Credenciales por defecto:' : 'Default credentials:'}
             </div>
             <div className="text-xs text-gray-500 mt-1">
-              {language === 'en' ? 'Username: admin | Password: admin123' : 'Usuario: admin | Contraseña: admin123'}
+              {isSpanish ? 'Usuario: admin | Contraseña: admin123' : 'Username: admin | Password: admin123'}
             </div>
           </div>
         </form>

--- a/court-kiosk/frontend/src/components/ModernCourtHeader.jsx
+++ b/court-kiosk/frontend/src/components/ModernCourtHeader.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { Scale, Globe, Shield } from 'lucide-react';
+import { Scale, Shield } from 'lucide-react';
+import { useLanguage } from '../contexts/LanguageContext';
+import LanguageSelector from './LanguageSelector';
 
-const ModernCourtHeader = ({ onLanguageToggle, currentLanguage = 'en' }) => {
+const ModernCourtHeader = ({ showLanguageSelector = true }) => {
+  const { t } = useLanguage();
+
   return (
     <header className="relative z-50 border-b border-border/50 bg-background/80 backdrop-blur-xl">
       <div className="max-w-7xl mx-auto px-6 lg:px-8">
@@ -13,31 +17,23 @@ const ModernCourtHeader = ({ onLanguageToggle, currentLanguage = 'en' }) => {
             </div>
             <div>
               <h1 className="text-xl font-display font-bold text-foreground">
-                San Mateo Family Court
+                {t('common.appName')}
               </h1>
               <p className="text-sm text-muted-foreground">
-                Self-Service Kiosk
+                {t('common.appSubtitle')}
               </p>
             </div>
           </div>
 
           {/* Right Section */}
           <div className="flex items-center space-x-4">
-            {/* Language Toggle */}
-            {onLanguageToggle && (
-              <button
-                onClick={onLanguageToggle}
-                className="inline-flex items-center space-x-2 px-4 py-2 rounded-lg bg-card/50 border border-border/50 text-sm font-medium text-foreground hover:bg-card/80 transition-colors"
-              >
-                <Globe className="w-4 h-4" />
-                <span>{currentLanguage === 'en' ? 'Español' : 'English'}</span>
-              </button>
-            )}
+            {/* Language Selector */}
+            {showLanguageSelector && <LanguageSelector size="sm" />}
 
             {/* Security Status */}
             <div className="inline-flex items-center space-x-2 px-3 py-2 rounded-lg bg-green-500/10 border border-green-500/20 text-sm font-medium text-green-600">
               <Shield className="w-4 h-4" />
-              <span>Secure Session</span>
+              <span>{t('common.secureSessionLabel')}</span>
             </div>
           </div>
         </div>

--- a/court-kiosk/frontend/src/components/ModernHeader.jsx
+++ b/court-kiosk/frontend/src/components/ModernHeader.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { Scale, Shield, Globe } from 'lucide-react';
+import { Scale, Shield } from 'lucide-react';
+import LanguageSelector from './LanguageSelector';
+import { useLanguage } from '../contexts/LanguageContext';
 
-const ModernHeader = ({ title, subtitle, showLanguageToggle = true, onLanguageToggle, currentLanguage = 'en' }) => {
+const ModernHeader = ({ title, subtitle, showLanguageToggle = true }) => {
+  const { t } = useLanguage();
+
   return (
     <header className="modern-header">
       <div className="header-container">
@@ -11,38 +15,29 @@ const ModernHeader = ({ title, subtitle, showLanguageToggle = true, onLanguageTo
               <Scale className="logo-scale" />
             </div>
             <div className="logo-text">
-              <h1 className="logo-title">San Mateo Family Court</h1>
-              <p className="logo-subtitle">Self-Service Kiosk</p>
+              <h1 className="logo-title">{t('common.appName')}</h1>
+              <p className="logo-subtitle">{t('common.appSubtitle')}</p>
             </div>
           </div>
         </div>
-        
+
         <div className="header-center">
           <div className="title-section">
             <h2 className="page-title">{title}</h2>
             {subtitle && <p className="page-subtitle">{subtitle}</p>}
           </div>
         </div>
-        
+
         <div className="header-right">
           <div className="header-actions">
             {showLanguageToggle && (
-              <button 
-                className="language-toggle"
-                onClick={onLanguageToggle}
-                title="Toggle Language"
-              >
-                <Globe className="globe-icon" />
-                <span className="language-text">
-                  {currentLanguage === 'en' ? 'Español' : 'English'}
-                </span>
-              </button>
+              <LanguageSelector className="language-selector-control" size="sm" />
             )}
-            
+
             <div className="system-status">
               <div className="status-indicator">
                 <Shield className="status-icon" />
-                <span className="status-text">Secure</span>
+                <span className="status-text">{t('common.secureLabel')}</span>
               </div>
             </div>
           </div>

--- a/court-kiosk/frontend/src/components/Navigation.jsx
+++ b/court-kiosk/frontend/src/components/Navigation.jsx
@@ -1,16 +1,40 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import LogoSeal from './LogoSeal';
+import { useLanguage } from '../contexts/LanguageContext';
+import LanguageSelector from './LanguageSelector';
 
 const Navigation = () => {
   const location = useLocation();
+  const { t } = useLanguage();
 
-  const navItems = [
-    { path: '/', label: 'Home', description: 'Main kiosk interface' },
-    { path: '/dvro', label: 'DVRO Flow', description: 'Original DVRO flow' },
-    { path: '/divorce', label: 'Divorce Flow', description: 'Divorce process guide' },
-    { path: '/admin', label: 'Admin', description: 'Administrative dashboard' }
-  ];
+  const navItems = useMemo(() => ([
+    {
+      path: '/',
+      label: t('navigation.home'),
+      description: t('navigation.homeDescription')
+    },
+    {
+      path: '/dvro',
+      label: t('navigation.dvroFlow'),
+      description: t('navigation.dvroDescription')
+    },
+    {
+      path: '/divorce',
+      label: t('navigation.divorceFlow'),
+      description: t('navigation.divorceDescription')
+    },
+    {
+      path: '/admin',
+      label: t('navigation.admin'),
+      description: t('navigation.adminDescription')
+    },
+    {
+      path: '/attorney',
+      label: t('navigation.attorney'),
+      description: t('navigation.attorneyDescription')
+    }
+  ]), [t]);
 
   return (
     <nav className="bg-white border-b border-gray-200 px-4 py-2">
@@ -41,9 +65,12 @@ const Navigation = () => {
               ))}
             </div>
           </div>
-          
-          <div className="text-xs text-gray-500">
-            Enhanced DVRO System
+
+          <div className="flex items-center gap-4">
+            <LanguageSelector size="sm" />
+            <div className="text-xs text-gray-500">
+              {t('navigation.footerTagline')}
+            </div>
           </div>
         </div>
       </div>

--- a/court-kiosk/frontend/src/contexts/LanguageContext.js
+++ b/court-kiosk/frontend/src/contexts/LanguageContext.js
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
+import translations, { supportedLanguages, fallbackLanguage } from '../i18n/translations';
 
 const LanguageContext = createContext();
 
@@ -11,21 +12,59 @@ export const useLanguage = () => {
 };
 
 export const LanguageProvider = ({ children }) => {
-  const [language, setLanguage] = useState('en');
+  const [language, setLanguage] = useState(fallbackLanguage);
 
-  const toggleLanguage = () => {
-    setLanguage(language === 'en' ? 'es' : 'en');
-  };
+  const toggleLanguage = useCallback(() => {
+    setLanguage((current) => {
+      const currentIndex = supportedLanguages.findIndex(({ code }) => code === current);
+      const nextIndex = (currentIndex + 1) % supportedLanguages.length;
+      return supportedLanguages[nextIndex]?.code ?? fallbackLanguage;
+    });
+  }, []);
 
-  const value = {
+  const activeTranslations = translations[language] || translations[fallbackLanguage];
+
+  const translate = useCallback((path, options = {}) => {
+    const segments = Array.isArray(path) ? path : String(path).split('.');
+    let result = activeTranslations;
+
+    for (const segment of segments) {
+      if (result && Object.prototype.hasOwnProperty.call(result, segment)) {
+        result = result[segment];
+      } else {
+        result = null;
+        break;
+      }
+    }
+
+    if (typeof result === 'string') {
+      if (options?.values) {
+        return Object.entries(options.values).reduce((acc, [key, value]) => (
+          acc.replace(new RegExp(`{{\\s*${key}\\s*}}`, 'g'), value)
+        ), result);
+      }
+      return result;
+    }
+
+    if (Array.isArray(result)) {
+      return result;
+    }
+
+    return options?.fallback ?? path;
+  }, [activeTranslations]);
+
+  const value = useMemo(() => ({
     language,
     setLanguage,
-    toggleLanguage
-  };
+    toggleLanguage,
+    availableLanguages: supportedLanguages,
+    t: translate,
+    translations: activeTranslations
+  }), [language, translate, activeTranslations, toggleLanguage]);
 
   return (
     <LanguageContext.Provider value={value}>
       {children}
     </LanguageContext.Provider>
   );
-}; 
+};

--- a/court-kiosk/frontend/src/i18n/translations.js
+++ b/court-kiosk/frontend/src/i18n/translations.js
@@ -1,0 +1,516 @@
+export const supportedLanguages = [
+  { code: 'en', label: 'English', shortLabel: 'EN' },
+  { code: 'es', label: 'Español', shortLabel: 'ES' },
+  { code: 'zh', label: '中文', shortLabel: '中文' }
+];
+
+export const fallbackLanguage = 'en';
+
+const translations = {
+  en: {
+    common: {
+      appName: 'San Mateo Family Court',
+      appSubtitle: 'Self-Service Kiosk',
+      secureLabel: 'Secure',
+      secureSessionLabel: 'Secure Session',
+      languageSelectorLabel: 'Language',
+      languageSelectorAriaLabel: 'Select language'
+    },
+    navigation: {
+      home: 'Home',
+      homeDescription: 'Main kiosk interface',
+      dvroFlow: 'DVRO Flow',
+      dvroDescription: 'Domestic Violence Restraining Order guide',
+      divorceFlow: 'Divorce Flow',
+      divorceDescription: 'Divorce process guide',
+      admin: 'Admin',
+      adminDescription: 'Administrative dashboard',
+      attorney: 'Attorney',
+      attorneyDescription: 'Attorney tools',
+      footerTagline: 'Enhanced DVRO System'
+    },
+    userKiosk: {
+      headerTitle: 'Family Law Self-Help Kiosk',
+      headerSubtitle: 'Select Your Case Type',
+      heroTitle: 'Select Your Case Type',
+      heroDescription: 'Choose the category that best describes your legal matter.',
+      caseTypes: {
+        A: {
+          title: 'Domestic Violence',
+          description: 'Restraining orders, protection orders, emergency cases.'
+        },
+        B: {
+          title: 'Child Custody & Support',
+          description: 'Child custody, support, visitation rights.'
+        },
+        C: {
+          title: 'Divorce & Separation',
+          description: 'Divorce, legal separation, serving papers, next steps.'
+        },
+        D: {
+          title: 'Other Family Law',
+          description: 'Parentage, guardianship, name change, and more.'
+        }
+      },
+      queueAssignedTitle: 'Queue Number Assigned',
+      queueAssignedSubtitle: 'Please wait to be called',
+      queueNumberLabel: 'YOUR QUEUE NUMBER',
+      priorityLevel: 'Priority {{value}}',
+      caseSummaryLabel: 'Case Summary',
+      nextStepsLabel: 'Next Steps',
+      waitMessageHeading: 'Please wait to be called',
+      waitMessageBody: "A facilitator will call your number when it's your turn. Please have a seat and wait.",
+      startOver: 'Start Over',
+      tileCallToAction: 'Tap to choose',
+      emergencyTitle: 'Emergency Help',
+      emergencyMessage: 'If you are in immediate danger, call 911. For same-day DVRO assistance, visit the Self-Help Center.',
+      locationLine1: 'Hall of Justice, 400 County Center, 6th Floor',
+      locationLine2: 'Mon–Fri · 8:00–12:00, 1:30–3:00',
+      locationLine3: 'Self-Help Center',
+      footer: 'San Mateo Superior Court © {{year}} · Family Law Self-Help Center',
+      processing: 'Processing...'
+    },
+    dvro: {
+      loading: 'Loading application...',
+      loadError: 'Failed to load application data',
+      tryAgain: 'Try Again',
+      backToHome: 'Back to Home',
+      clinicName: 'Family Court Clinic',
+      heroTitle: 'Domestic Violence Restraining Orders',
+      heroDescription: "Get help applying for a restraining order. We'll guide you step by step with information and specific forms.",
+      emergencyNotice: 'If you are in immediate danger, call 911.',
+      emergencyAction: 'You can now begin your application.',
+      startApplication: 'Start Application',
+      startDetails: 'Free and confidential • 15-20 minutes',
+      quickInfo: [
+        {
+          title: 'Information',
+          description: 'Learn about the legal process, your rights, and the options available for your specific situation.'
+        },
+        {
+          title: 'Questions',
+          description: 'Answer simple questions about your situation to receive personalized and specific guidance.'
+        },
+        {
+          title: 'Forms',
+          description: 'Get the specific forms you need for your case, with detailed instructions.'
+        }
+      ],
+      whyTitle: 'Why use this system?',
+      whyCards: [
+        {
+          title: 'Complete Information',
+          description: 'Every question includes contextual information so you understand completely before making decisions.'
+        },
+        {
+          title: 'Specific Forms',
+          description: 'Receive only the forms you need for your specific situation, without confusion.'
+        }
+      ]
+    },
+    divorce: {
+      backToHome: 'Back to Home',
+      clinicName: 'Family Court Clinic',
+      heroTitle: 'Divorce & Legal Separation',
+      heroDescription: "Get help with divorce proceedings, legal separation, and property division. We'll guide you step by step with information and specific forms needed for your case.",
+      infoBanner: 'Understanding your rights and the divorce process is crucial. This guide will help you navigate the legal requirements and prepare the necessary documentation.',
+      startGuide: 'Start Divorce Guide',
+      startDetails: 'Free and confidential · 20-30 minutes · Step-by-step guidance',
+      learnTitle: "What You'll Learn",
+      learnCards: [
+        {
+          title: 'Residency Requirements',
+          description: "Understand California's residency requirements and eligibility for filing divorce proceedings."
+        },
+        {
+          title: 'Required Forms',
+          description: 'Learn about essential forms like FL-100 (Petition), FL-110 (Summons), and child custody forms if applicable.'
+        },
+        {
+          title: 'Service Requirements',
+          description: 'Understand how to properly serve divorce papers to your spouse within the required timeframe.'
+        },
+        {
+          title: 'Next Steps',
+          description: 'Get guidance on what happens after filing, including response periods and court procedures.'
+        }
+      ],
+      notesTitle: 'Important Information',
+      notes: [
+        'This guide provides general information and is not legal advice.',
+        'For complex cases or legal advice, consult with an attorney.',
+        'Court staff can help with procedural questions but cannot provide legal advice.',
+        'All forms and procedures must comply with California family law requirements.'
+      ]
+    },
+    experiment: {
+      heroTitle: 'Professional Legal Assistance',
+      heroSubtitle: 'Family Law',
+      heroTagline: 'Self-Help Kiosk',
+      intro: 'Select Your Case Type to Begin',
+      description: 'Choose a program to start a guided experience tailored to your legal needs.',
+      supportTitle: 'Need Assistance?',
+      supportDescription: 'Court facilitators are available to answer questions and provide additional guidance.',
+      caseTypes: {
+        dvro: {
+          title: 'Domestic Violence',
+          description: 'Restraining orders, protection orders, emergency cases. Immediate assistance for safety and legal protection.',
+          priority: 'PRIORITY A'
+        },
+        custody: {
+          title: 'Child Custody & Support',
+          description: "Child custody arrangements, support calculations, and visitation rights. Protecting children's best interests.",
+          priority: 'PRIORITY B'
+        },
+        divorce: {
+          title: 'Divorce & Separation',
+          description: 'Divorce proceedings, legal separation, serving papers, and next steps. Guided process for life transitions.',
+          priority: 'PRIORITY C'
+        },
+        other: {
+          title: 'Other Family Law',
+          description: 'Parentage, guardianship, name changes, adoption, and other family legal matters. Comprehensive support.',
+          priority: 'PRIORITY D'
+        }
+      }
+    }
+  },
+  es: {
+    common: {
+      appName: 'Tribunal de Familia de San Mateo',
+      appSubtitle: 'Quiosco de Autoservicio',
+      secureLabel: 'Seguro',
+      secureSessionLabel: 'Sesión Segura',
+      languageSelectorLabel: 'Idioma',
+      languageSelectorAriaLabel: 'Seleccionar idioma'
+    },
+    navigation: {
+      home: 'Inicio',
+      homeDescription: 'Interfaz principal del quiosco',
+      dvroFlow: 'Proceso DVRO',
+      dvroDescription: 'Guía de órdenes de restricción por violencia doméstica',
+      divorceFlow: 'Proceso de Divorcio',
+      divorceDescription: 'Guía del proceso de divorcio',
+      admin: 'Administración',
+      adminDescription: 'Panel administrativo',
+      attorney: 'Abogado',
+      attorneyDescription: 'Herramientas para abogados',
+      footerTagline: 'Sistema DVRO Mejorado'
+    },
+    userKiosk: {
+      headerTitle: 'Quiosco de Autoayuda de Derecho de Familia',
+      headerSubtitle: 'Seleccione su Tipo de Caso',
+      heroTitle: 'Seleccione su Tipo de Caso',
+      heroDescription: 'Elija la categoría que mejor describa su asunto legal.',
+      caseTypes: {
+        A: {
+          title: 'Violencia Doméstica',
+          description: 'Órdenes de restricción, órdenes de protección, casos de emergencia.'
+        },
+        B: {
+          title: 'Custodia y Manutención Infantil',
+          description: 'Custodia de menores, manutención infantil, derechos de visita.'
+        },
+        C: {
+          title: 'Divorcio y Separación',
+          description: 'Divorcio, separación legal, entrega de documentos, próximos pasos.'
+        },
+        D: {
+          title: 'Otros Asuntos de Familia',
+          description: 'Paternidad, tutela, cambio de nombre y más.'
+        }
+      },
+      queueAssignedTitle: 'Número de Cola Asignado',
+      queueAssignedSubtitle: 'Por favor espera a ser llamado',
+      queueNumberLabel: 'TU NÚMERO DE COLA',
+      priorityLevel: 'Prioridad {{value}}',
+      caseSummaryLabel: 'Resumen del Caso',
+      nextStepsLabel: 'Próximos Pasos',
+      waitMessageHeading: 'Por favor espera a ser llamado',
+      waitMessageBody: 'Un facilitador llamará su número cuando sea su turno. Por favor tome asiento y espere.',
+      startOver: 'Comenzar de Nuevo',
+      tileCallToAction: 'Toque para elegir',
+      emergencyTitle: 'Ayuda de Emergencia',
+      emergencyMessage: 'Si está en peligro inmediato, llame al 911. Para asistencia de DVRO el mismo día, visite el Centro de Autoayuda.',
+      locationLine1: 'Palacio de Justicia, 400 County Center, 6.º piso',
+      locationLine2: 'Lun–Vie · 8:00–12:00, 1:30–3:00',
+      locationLine3: 'Centro de Autoayuda',
+      footer: 'Tribunal Superior de San Mateo © {{year}} · Centro de Autoayuda de Derecho de Familia',
+      processing: 'Procesando...'
+    },
+    dvro: {
+      loading: 'Cargando la aplicación...',
+      loadError: 'No se pudieron cargar los datos',
+      tryAgain: 'Intentar de Nuevo',
+      backToHome: 'Volver al Inicio',
+      clinicName: 'Clínica del Tribunal de Familia',
+      heroTitle: 'Órdenes de Restricción por Violencia Doméstica',
+      heroDescription: 'Obtenga ayuda para solicitar una orden de restricción. Le guiaremos paso a paso con información y formularios específicos.',
+      emergencyNotice: 'Si está en peligro inmediato, llame al 911.',
+      emergencyAction: 'Ahora puede comenzar su solicitud.',
+      startApplication: 'Comenzar Solicitud',
+      startDetails: 'Gratis y confidencial • 15-20 minutos',
+      quickInfo: [
+        {
+          title: 'Información',
+          description: 'Aprenda sobre el proceso legal, sus derechos y las opciones disponibles para su situación específica.'
+        },
+        {
+          title: 'Preguntas',
+          description: 'Responda preguntas simples sobre su situación para recibir orientación personalizada y específica.'
+        },
+        {
+          title: 'Formularios',
+          description: 'Obtenga los formularios específicos que necesita para su caso, con instrucciones detalladas.'
+        }
+      ],
+      whyTitle: '¿Por qué usar este sistema?',
+      whyCards: [
+        {
+          title: 'Información Completa',
+          description: 'Cada pregunta incluye información contextual para que comprenda completamente antes de tomar decisiones.'
+        },
+        {
+          title: 'Formularios Específicos',
+          description: 'Reciba solo los formularios que necesita para su situación específica, sin confusión.'
+        }
+      ]
+    },
+    divorce: {
+      backToHome: 'Volver al Inicio',
+      clinicName: 'Clínica del Tribunal de Familia',
+      heroTitle: 'Divorcio y Separación Legal',
+      heroDescription: 'Obtenga ayuda con los procedimientos de divorcio, separación legal y división de bienes. Le guiaremos paso a paso con la información y los formularios específicos que necesita para su caso.',
+      infoBanner: 'Comprender sus derechos y el proceso de divorcio es fundamental. Esta guía le ayudará a navegar los requisitos legales y preparar la documentación necesaria.',
+      startGuide: 'Iniciar Guía de Divorcio',
+      startDetails: 'Gratis y confidencial · 20-30 minutos · Guía paso a paso',
+      learnTitle: 'Lo que aprenderá',
+      learnCards: [
+        {
+          title: 'Requisitos de Residencia',
+          description: 'Comprenda los requisitos de residencia de California y la elegibilidad para presentar un divorcio.'
+        },
+        {
+          title: 'Formularios Requeridos',
+          description: 'Conozca los formularios esenciales como FL-100 (Petición), FL-110 (Citatorio) y formularios de custodia infantil si aplica.'
+        },
+        {
+          title: 'Requisitos de Notificación',
+          description: 'Aprenda cómo notificar legalmente a su cónyuge dentro del plazo requerido.'
+        },
+        {
+          title: 'Próximos Pasos',
+          description: 'Obtenga orientación sobre lo que sucede después de presentar, incluidos los plazos de respuesta y los procedimientos judiciales.'
+        }
+      ],
+      notesTitle: 'Información Importante',
+      notes: [
+        'Esta guía ofrece información general y no constituye asesoría legal.',
+        'Para casos complejos o asesoría legal, consulte con un abogado.',
+        'El personal del tribunal puede responder preguntas de procedimiento pero no brindar asesoría legal.',
+        'Todos los formularios y procedimientos deben cumplir con los requisitos del derecho de familia de California.'
+      ]
+    },
+    experiment: {
+      heroTitle: 'Asistencia Legal Profesional',
+      heroSubtitle: 'Derecho de Familia',
+      heroTagline: 'Quiosco de Autoayuda',
+      intro: 'Seleccione su Tipo de Caso para Comenzar',
+      description: 'Elija un programa para iniciar una experiencia guiada adaptada a sus necesidades legales.',
+      supportTitle: '¿Necesita Asistencia?',
+      supportDescription: 'Los facilitadores del tribunal están disponibles para responder preguntas y brindar orientación adicional.',
+      caseTypes: {
+        dvro: {
+          title: 'Violencia Doméstica',
+          description: 'Órdenes de restricción, órdenes de protección y casos de emergencia. Asistencia inmediata para su seguridad y protección legal.',
+          priority: 'PRIORIDAD A'
+        },
+        custody: {
+          title: 'Custodia y Manutención',
+          description: 'Acuerdos de custodia, cálculos de manutención y derechos de visita. Protegiendo el interés superior de los menores.',
+          priority: 'PRIORIDAD B'
+        },
+        divorce: {
+          title: 'Divorcio y Separación',
+          description: 'Procedimientos de divorcio, separación legal, entrega de documentos y próximos pasos. Proceso guiado para transiciones de vida.',
+          priority: 'PRIORIDAD C'
+        },
+        other: {
+          title: 'Otros Asuntos de Familia',
+          description: 'Paternidad, tutela, cambios de nombre, adopción y otros asuntos legales familiares. Apoyo integral.',
+          priority: 'PRIORIDAD D'
+        }
+      }
+    }
+  },
+  zh: {
+    common: {
+      appName: '圣马特奥家庭法院',
+      appSubtitle: '自助服务终端',
+      secureLabel: '安全',
+      secureSessionLabel: '安全会话',
+      languageSelectorLabel: '语言',
+      languageSelectorAriaLabel: '选择语言'
+    },
+    navigation: {
+      home: '主页',
+      homeDescription: '终端主界面',
+      dvroFlow: '家庭暴力限制流程',
+      dvroDescription: '家庭暴力限制令指南',
+      divorceFlow: '离婚流程',
+      divorceDescription: '离婚流程指南',
+      admin: '管理',
+      adminDescription: '管理控制台',
+      attorney: '律师',
+      attorneyDescription: '律师工具',
+      footerTagline: '增强的 DVRO 系统'
+    },
+    userKiosk: {
+      headerTitle: '家庭法律自助服务终端',
+      headerSubtitle: '请选择您的案件类型',
+      heroTitle: '请选择您的案件类型',
+      heroDescription: '请选择最符合您法律事务的类别。',
+      caseTypes: {
+        A: {
+          title: '家庭暴力',
+          description: '限制令、保护令、紧急案件。'
+        },
+        B: {
+          title: '子女监护与抚养',
+          description: '子女监护、抚养、探视权。'
+        },
+        C: {
+          title: '离婚与分居',
+          description: '离婚、法律分居、送达文件、下一步。'
+        },
+        D: {
+          title: '其他家庭法律事务',
+          description: '亲子关系、监护、改名等。'
+        }
+      },
+      queueAssignedTitle: '已分配排队号码',
+      queueAssignedSubtitle: '请等待叫号',
+      queueNumberLabel: '您的排队号码',
+      priorityLevel: '优先级 {{value}}',
+      caseSummaryLabel: '案件摘要',
+      nextStepsLabel: '下一步',
+      waitMessageHeading: '请等待叫号',
+      waitMessageBody: '到您服务时，工作人员会叫号。请就座等候。',
+      startOver: '重新开始',
+      tileCallToAction: '点击选择',
+      emergencyTitle: '紧急协助',
+      emergencyMessage: '如有紧急危险，请拨打 911。若需当日的家庭暴力限制令协助，请前往自助服务中心。',
+      locationLine1: '司法大楼，County Center 400 号，6 楼',
+      locationLine2: '周一至周五 · 8:00–12:00，13:30–15:00',
+      locationLine3: '自助服务中心',
+      footer: '圣马特奥高等法院 © {{year}} · 家庭法律自助服务中心',
+      processing: '处理中…'
+    },
+    dvro: {
+      loading: '正在加载应用…',
+      loadError: '无法加载应用数据',
+      tryAgain: '重试',
+      backToHome: '返回首页',
+      clinicName: '家庭法院服务中心',
+      heroTitle: '家庭暴力限制令',
+      heroDescription: '获取申请限制令的帮助。我们将为您提供逐步指导及所需的具体表格。',
+      emergencyNotice: '如有紧急危险，请拨打 911。',
+      emergencyAction: '现在可以开始填写申请。',
+      startApplication: '开始申请',
+      startDetails: '免费且保密 • 15-20 分钟',
+      quickInfo: [
+        {
+          title: '信息',
+          description: '了解法律程序、您的权利，以及适用于您情况的可选方案。'
+        },
+        {
+          title: '问题',
+          description: '回答几个关于您情况的问题，以获得个性化的指导。'
+        },
+        {
+          title: '表格',
+          description: '获取适用于您案件的具体表格和详细说明。'
+        }
+      ],
+      whyTitle: '为什么使用本系统？',
+      whyCards: [
+        {
+          title: '完整信息',
+          description: '每个问题都附带背景说明，帮助您在做决定前充分了解情况。'
+        },
+        {
+          title: '专属表格',
+          description: '只提供您所需的表格，避免混淆。'
+        }
+      ]
+    },
+    divorce: {
+      backToHome: '返回首页',
+      clinicName: '家庭法院服务中心',
+      heroTitle: '离婚与法律分居',
+      heroDescription: '获取有关离婚程序、法律分居和财产分割的帮助。我们将提供逐步指导以及您案件所需的具体表格。',
+      infoBanner: '了解您的权利和离婚流程至关重要。本指南将帮助您掌握法律要求并准备必要的文件。',
+      startGuide: '开始离婚指南',
+      startDetails: '免费且保密 · 20-30 分钟 · 分步指导',
+      learnTitle: '您将了解',
+      learnCards: [
+        {
+          title: '居住要求',
+          description: '了解加州的居住要求以及申请离婚的资格。'
+        },
+        {
+          title: '必备表格',
+          description: '了解关键表格，如 FL-100（申请书）、FL-110（传票）以及适用的儿童监护表格。'
+        },
+        {
+          title: '送达要求',
+          description: '了解如何在规定时间内向配偶送达离婚文件。'
+        },
+        {
+          title: '下一步',
+          description: '了解提交申请后的流程，包括答复期限和法院程序。'
+        }
+      ],
+      notesTitle: '重要信息',
+      notes: [
+        '本指南仅提供一般信息，不构成法律意见。',
+        '复杂案件或需法律意见时，请咨询律师。',
+        '法院工作人员可解答程序性问题，但不能提供法律意见。',
+        '所有表格与程序必须符合加州家庭法要求。'
+      ]
+    },
+    experiment: {
+      heroTitle: '专业法律协助',
+      heroSubtitle: '家庭法',
+      heroTagline: '自助服务终端',
+      intro: '请选择您的案件类型开始',
+      description: '选择一个项目，开始为您的法律需求量身定制的引导式体验。',
+      supportTitle: '需要帮助吗？',
+      supportDescription: '法院辅导员可提供答疑与额外指导。',
+      caseTypes: {
+        dvro: {
+          title: '家庭暴力',
+          description: '限制令、保护令、紧急案件。为安全与法律保护提供即时协助。',
+          priority: '优先级 A'
+        },
+        custody: {
+          title: '子女监护与抚养',
+          description: '子女监护安排、抚养费计算与探视权。保障儿童的最佳利益。',
+          priority: '优先级 B'
+        },
+        divorce: {
+          title: '离婚与分居',
+          description: '离婚程序、法律分居、送达文件及后续步骤。为人生转变提供引导流程。',
+          priority: '优先级 C'
+        },
+        other: {
+          title: '其他家庭法律事务',
+          description: '亲子关系、监护、改名、收养等家庭法律事务。提供全方位支持。',
+          priority: '优先级 D'
+        }
+      }
+    }
+  }
+};
+
+export default translations;

--- a/court-kiosk/frontend/src/pages/AdminDashboard.jsx
+++ b/court-kiosk/frontend/src/pages/AdminDashboard.jsx
@@ -1,14 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useAuth } from '../contexts/AuthContext';
-import { Users, CheckCircle, RefreshCw, Shield, Heart, FileText, Globe, Phone, Mail, Clock, AlertTriangle, Send, Eye, X, LogOut, User as UserIcon } from 'lucide-react';
+import { Users, CheckCircle, RefreshCw, Shield, Heart, FileText, Phone, Mail, Clock, AlertTriangle, Send, Eye, X, LogOut, User as UserIcon } from 'lucide-react';
 import { getQueue, callNext, completeCase, addTestData, sendComprehensiveEmail } from '../utils/queueAPI';
 import { getAdminQueue, callNextAuthenticated, completeCaseAuthenticated } from '../utils/authAPI';
 import FormsManagement from '../components/FormsManagement';
 import FormsSummary from '../components/FormsSummary';
+import LanguageSelector from '../components/LanguageSelector';
 
 const AdminDashboard = () => {
-  const { language, toggleLanguage } = useLanguage();
+  const { language } = useLanguage();
   const { user, logout, sessionToken } = useAuth();
   const [activeTab, setActiveTab] = useState('queue'); // 'queue' or 'forms'
   const [queue, setQueue] = useState([]);
@@ -149,9 +150,9 @@ const AdminDashboard = () => {
       
       if (result.success) {
         setError(null);
-        alert(language === 'en' 
-          ? `Email sent successfully to ${caseItem.user_email}` 
-          : `Correo enviado exitosamente a ${caseItem.user_email}`);
+        alert(language === 'es' 
+          ? `Correo enviado exitosamente a ${caseItem.user_email}` 
+          : `Email sent successfully to ${caseItem.user_email}`);
       } else {
         setError(result.error || 'Failed to send email');
       }
@@ -299,7 +300,7 @@ const AdminDashboard = () => {
         <div className="text-center">
           <RefreshCw className="w-12 h-12 text-blue-600 mx-auto mb-4 animate-spin" />
           <p className="text-gray-600">
-            {language === 'en' ? 'Loading queue...' : 'Cargando cola...'}
+            {language === 'es' ? 'Cargando cola...' : 'Loading queue...'}
           </p>
         </div>
       </div>
@@ -314,31 +315,31 @@ const AdminDashboard = () => {
           <div className="flex justify-between items-center">
             <div>
               <h1 className="text-3xl font-bold text-gray-900">
-                {language === 'en' ? 'Facilitator Dashboard' : 'Panel del Facilitador'}
+                {language === 'es' ? 'Panel del Facilitador' : 'Facilitator Dashboard'}
               </h1>
               <p className="text-gray-600 mt-1">
-                {language === 'en' 
-                  ? 'Manage queue and assist clients'
-                  : 'Gestiona la cola y asiste a los clientes'
+                {language === 'es' 
+                  ? 'Gestiona la cola y asiste a los clientes'
+                  : 'Manage queue and assist clients'
                 }
               </p>
               <div className="flex space-x-6 mt-3">
                 <div className="flex items-center space-x-2">
                   <div className="w-3 h-3 bg-yellow-500 rounded-full"></div>
                   <span className="text-sm font-medium text-gray-700">
-                    {language === 'en' ? 'Waiting:' : 'Esperando:'} {waitingCount}
+                    {language === 'es' ? 'Esperando:' : 'Waiting:'} {waitingCount}
                   </span>
                 </div>
                 <div className="flex items-center space-x-2">
                   <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
                   <span className="text-sm font-medium text-gray-700">
-                    {language === 'en' ? 'In Progress:' : 'En Progreso:'} {inProgressCount}
+                    {language === 'es' ? 'En Progreso:' : 'In Progress:'} {inProgressCount}
                   </span>
                 </div>
                 <div className="flex items-center space-x-2">
                   <div className="w-3 h-3 bg-green-500 rounded-full"></div>
                   <span className="text-sm font-medium text-gray-700">
-                    {language === 'en' ? 'Completed:' : 'Completado:'} {completedCount}
+                    {language === 'es' ? 'Completado:' : 'Completed:'} {completedCount}
                   </span>
                 </div>
               </div>
@@ -349,22 +350,16 @@ const AdminDashboard = () => {
                 className="flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
               >
                 <RefreshCw className="w-4 h-4 mr-2" />
-                {language === 'en' ? 'Refresh' : 'Actualizar'}
+                {language === 'es' ? 'Actualizar' : 'Refresh'}
               </button>
               <button
                 onClick={handleAddTestData}
                 className="flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
               >
                 <CheckCircle className="w-4 h-4 mr-2" />
-                {language === 'en' ? 'Add Test Data' : 'Agregar Datos de Prueba'}
+                {language === 'es' ? 'Agregar Datos de Prueba' : 'Add Test Data'}
               </button>
-              <button
-                onClick={toggleLanguage}
-                className="flex items-center px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
-              >
-                <Globe className="w-4 h-4 mr-2" />
-                {language === 'en' ? 'Español' : 'English'}
-              </button>
+              <LanguageSelector size="sm" />
               {user && (
                 <div className="flex items-center space-x-2">
                   <div className="flex items-center px-3 py-2 bg-purple-100 text-purple-800 rounded-lg">
@@ -376,7 +371,7 @@ const AdminDashboard = () => {
                     className="flex items-center px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
                   >
                     <LogOut className="w-4 h-4 mr-2" />
-                    {language === 'en' ? 'Logout' : 'Cerrar Sesión'}
+                    {language === 'es' ? 'Cerrar Sesión' : 'Logout'}
                   </button>
                 </div>
               )}
@@ -399,7 +394,7 @@ const AdminDashboard = () => {
             >
               <div className="flex items-center">
                 <Users className="w-4 h-4 mr-2" />
-                {language === 'en' ? 'Queue Management' : 'Gestión de Cola'}
+                {language === 'es' ? 'Gestión de Cola' : 'Queue Management'}
               </div>
             </button>
             <button
@@ -412,7 +407,7 @@ const AdminDashboard = () => {
             >
               <div className="flex items-center">
                 <FileText className="w-4 h-4 mr-2" />
-                {language === 'en' ? 'Forms Management' : 'Gestión de Formularios'}
+                {language === 'es' ? 'Gestión de Formularios' : 'Forms Management'}
               </div>
             </button>
           </nav>
@@ -438,11 +433,11 @@ const AdminDashboard = () => {
                 <div className="flex items-center">
                   <AlertTriangle className="w-5 h-5 mr-2" />
                   <span className="font-semibold">
-                    {language === 'en' ? 'Long Wait Alert:' : 'Alerta de Espera Larga:'}
+                    {language === 'es' ? 'Alerta de Espera Larga:' : 'Long Wait Alert:'}
                   </span>
                   <span className="ml-2">
                     {queueWithWaitTimes.filter(item => item.waitTimeMinutes >= 30).length} 
-                    {language === 'en' ? ' clients waiting 30+ minutes' : ' clientes esperando 30+ minutos'}
+                    {language === 'es' ? ' clientes esperando 30+ minutos' : ' clients waiting 30+ minutes'}
                   </span>
                 </div>
               </div>
@@ -454,7 +449,7 @@ const AdminDashboard = () => {
         <div className="max-w-7xl mx-auto px-4 py-6">
           <div className="bg-white rounded-lg shadow-lg p-6">
             <h2 className="text-2xl font-bold text-gray-900 mb-4">
-              {language === 'en' ? 'Currently Serving' : 'Atendiendo Actualmente'}
+              {language === 'es' ? 'Atendiendo Actualmente' : 'Currently Serving'}
             </h2>
             <div className="flex items-center justify-between">
               <div className="flex items-center">
@@ -468,16 +463,16 @@ const AdminDashboard = () => {
                     {getPriorityLabel(currentNumber.priority || currentNumber.priority_level)[language]}
                   </h3>
                   <p className="text-gray-600">
-                    {language === 'en' ? 'Priority' : 'Prioridad'} {currentNumber.priority || currentNumber.priority_level}
+                    {language === 'es' ? 'Prioridad' : 'Priority'} {currentNumber.priority || currentNumber.priority_level}
                   </p>
                   {currentNumber.user_name && (
                     <p className="text-gray-600">
-                      {language === 'en' ? 'Name:' : 'Nombre:'} {currentNumber.user_name}
+                      {language === 'es' ? 'Nombre:' : 'Name:'} {currentNumber.user_name}
                     </p>
                   )}
                   {currentNumber.created_at && (
                     <p className="text-gray-600">
-                      {language === 'en' ? 'Wait time:' : 'Tiempo de espera:'} {calculateWaitTime(currentNumber.created_at)}
+                      {language === 'es' ? 'Tiempo de espera:' : 'Wait time:'} {calculateWaitTime(currentNumber.created_at)}
                     </p>
                   )}
                 </div>
@@ -488,14 +483,14 @@ const AdminDashboard = () => {
                   className="flex items-center px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
                 >
                   <Eye className="w-4 h-4 mr-2" />
-                  {language === 'en' ? 'Case Summary' : 'Resumen del Caso'}
+                  {language === 'es' ? 'Resumen del Caso' : 'Case Summary'}
                 </button>
                 <button
                   onClick={() => handleCompleteCase(currentNumber.queue_number)}
                   className="flex items-center px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
                 >
                   <CheckCircle className="w-4 h-4 mr-2" />
-                  {language === 'en' ? 'Complete Case' : 'Completar Caso'}
+                  {language === 'es' ? 'Completar Caso' : 'Complete Case'}
                 </button>
               </div>
             </div>
@@ -510,7 +505,7 @@ const AdminDashboard = () => {
           disabled={waitingCount === 0}
           className="w-full bg-blue-600 text-white py-4 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-xl font-semibold"
         >
-          {language === 'en' ? 'Call Next Number' : 'Llamar Siguiente Número'}
+          {language === 'es' ? 'Llamar Siguiente Número' : 'Call Next Number'}
         </button>
       </div>
 
@@ -519,7 +514,7 @@ const AdminDashboard = () => {
         <div className="max-w-7xl mx-auto px-4 py-4">
           <div className="bg-white rounded-lg shadow-md p-6">
             <h2 className="text-xl font-semibold text-gray-900 mb-4">
-              {language === 'en' ? 'Currently In Progress' : 'Actualmente En Progreso'}
+              {language === 'es' ? 'Actualmente En Progreso' : 'Currently In Progress'}
             </h2>
             <div className="space-y-3">
               {queueWithWaitTimes.filter(item => item.status === 'in_progress').map((item) => (
@@ -550,7 +545,7 @@ const AdminDashboard = () => {
                     className="flex items-center px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors"
                   >
                     <CheckCircle className="w-3 h-3 mr-1" />
-                    {language === 'en' ? 'Complete' : 'Completar'}
+                    {language === 'es' ? 'Completar' : 'Complete'}
                   </button>
                 </div>
               ))}
@@ -565,7 +560,7 @@ const AdminDashboard = () => {
           {/* Queue by Priority - Left Column */}
           <div className="lg:col-span-2">
             <h2 className="text-2xl font-bold text-gray-900 mb-6">
-              {language === 'en' ? 'Queue by Priority' : 'Cola por Prioridad'}
+              {language === 'es' ? 'Cola por Prioridad' : 'Queue by Priority'}
             </h2>
             
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -584,14 +579,14 @@ const AdminDashboard = () => {
                           {getPriorityLabel(priority)[language]}
                         </h3>
                         <p className="text-gray-600">
-                          {priorityItems.filter(item => item.status === 'waiting').length} {language === 'en' ? 'waiting' : 'esperando'}
+                          {priorityItems.filter(item => item.status === 'waiting').length} {language === 'es' ? 'esperando' : 'waiting'}
                         </p>
                       </div>
                     </div>
 
                     {priorityItems.filter(item => item.status === 'waiting').length === 0 ? (
                       <p className="text-gray-500 text-center py-4">
-                        {language === 'en' ? 'No cases waiting' : 'No hay casos esperando'}
+                        {language === 'es' ? 'No hay casos esperando' : 'No cases waiting'}
                       </p>
                     ) : (
                       <div className="space-y-2">
@@ -638,7 +633,7 @@ const AdminDashboard = () => {
                                     }}
                                     disabled={sendingEmail}
                                     className="flex items-center px-2 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700 disabled:opacity-50 transition-colors"
-                                    title={language === 'en' ? 'Send Email Summary' : 'Enviar Resumen por Correo'}
+                                    title={language === 'es' ? 'Enviar Resumen por Correo' : 'Send Email Summary'}
                                   >
                                     <Send className="w-3 h-3" />
                                   </button>
@@ -652,17 +647,17 @@ const AdminDashboard = () => {
                                     className="flex items-center px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors"
                                   >
                                     <CheckCircle className="w-3 h-3 mr-1" />
-                                    {language === 'en' ? 'Complete' : 'Completar'}
+                                    {language === 'es' ? 'Completar' : 'Complete'}
                                   </button>
                                 )}
                                 {item.status === 'in_progress' && (
                                   <span className="px-3 py-1 bg-blue-100 text-blue-800 rounded text-sm">
-                                    {language === 'en' ? 'In Progress' : 'En Progreso'}
+                                    {language === 'es' ? 'En Progreso' : 'In Progress'}
                                   </span>
                                 )}
                                 {item.status === 'completed' && (
                                   <span className="px-3 py-1 bg-gray-100 text-gray-800 rounded text-sm">
-                                    {language === 'en' ? 'Completed' : 'Completado'}
+                                    {language === 'es' ? 'Completado' : 'Completed'}
                                   </span>
                                 )}
                               </div>
@@ -680,7 +675,7 @@ const AdminDashboard = () => {
           {/* Case Details - Right Column */}
           <div className="lg:col-span-1">
             <h2 className="text-2xl font-bold text-gray-900 mb-6">
-              {language === 'en' ? 'Case Details' : 'Detalles del Caso'}
+              {language === 'es' ? 'Detalles del Caso' : 'Case Details'}
             </h2>
             
             {selectedCase ? (
@@ -703,19 +698,19 @@ const AdminDashboard = () => {
                     
                     <div className="grid grid-cols-2 gap-4 text-sm">
                       <div>
-                        <p className="text-gray-500">{language === 'en' ? 'Case Type' : 'Tipo de Caso'}</p>
+                        <p className="text-gray-500">{language === 'es' ? 'Tipo de Caso' : 'Case Type'}</p>
                         <p className="font-medium">{selectedCase.case_type || getPriorityLabel(selectedCase.priority || selectedCase.priority_level)[language]}</p>
                       </div>
                       <div>
-                        <p className="text-gray-500">{language === 'en' ? 'Status' : 'Estado'}</p>
+                        <p className="text-gray-500">{language === 'es' ? 'Estado' : 'Status'}</p>
                         <p className="font-medium capitalize">{selectedCase.status}</p>
                       </div>
                       <div>
-                        <p className="text-gray-500">{language === 'en' ? 'Language' : 'Idioma'}</p>
+                        <p className="text-gray-500">{language === 'es' ? 'Idioma' : 'Language'}</p>
                         <p className="font-medium uppercase">{selectedCase.language}</p>
                       </div>
                       <div>
-                        <p className="text-gray-500">{language === 'en' ? 'Wait Time' : 'Tiempo de Espera'}</p>
+                        <p className="text-gray-500">{language === 'es' ? 'Tiempo de Espera' : 'Wait Time'}</p>
                         <p className={`font-medium ${getWaitTimeColor(selectedCase.waitTimeMinutes || 0)}`}>
                           {selectedCase.waitTimeFormatted || calculateWaitTime(selectedCase.arrived_at || selectedCase.timestamp || selectedCase.created_at)}
                         </p>
@@ -727,7 +722,7 @@ const AdminDashboard = () => {
                 {/* User Information */}
                 {(selectedCase.user_name || selectedCase.user_email || selectedCase.phone_number) && (
                   <div>
-                    <h4 className="font-semibold text-gray-900 mb-3">{language === 'en' ? 'User Information' : 'Información del Usuario'}</h4>
+                    <h4 className="font-semibold text-gray-900 mb-3">{language === 'es' ? 'Información del Usuario' : 'User Information'}</h4>
                     <div className="space-y-2">
                       {selectedCase.user_name && (
                         <div className="flex items-center text-sm">
@@ -754,7 +749,7 @@ const AdminDashboard = () => {
                 {/* Case Summary */}
                 {caseSummary && (
                   <div>
-                    <h4 className="font-semibold text-gray-900 mb-3">{language === 'en' ? 'Case Summary' : 'Resumen del Caso'}</h4>
+                    <h4 className="font-semibold text-gray-900 mb-3">{language === 'es' ? 'Resumen del Caso' : 'Case Summary'}</h4>
                     <div className="bg-gray-50 rounded-lg p-4">
                       <p className="text-sm text-gray-700 whitespace-pre-wrap">{caseSummary}</p>
                     </div>
@@ -764,7 +759,7 @@ const AdminDashboard = () => {
                 {/* Conversation Summary */}
                 {selectedCase.conversation_summary && (
                   <div>
-                    <h4 className="font-semibold text-gray-900 mb-3">{language === 'en' ? 'Conversation Summary' : 'Resumen de Conversación'}</h4>
+                    <h4 className="font-semibold text-gray-900 mb-3">{language === 'es' ? 'Resumen de Conversación' : 'Conversation Summary'}</h4>
                     <div className="bg-blue-50 rounded-lg p-4">
                       <p className="text-sm text-gray-700 whitespace-pre-wrap">{selectedCase.conversation_summary}</p>
                     </div>
@@ -774,7 +769,7 @@ const AdminDashboard = () => {
                 {/* Current Node */}
                 {selectedCase.current_node && (
                   <div>
-                    <h4 className="font-semibold text-gray-900 mb-3">{language === 'en' ? 'Current Step' : 'Paso Actual'}</h4>
+                    <h4 className="font-semibold text-gray-900 mb-3">{language === 'es' ? 'Paso Actual' : 'Current Step'}</h4>
                     <div className="bg-yellow-50 rounded-lg p-4">
                       <p className="text-sm text-gray-700">{selectedCase.current_node}</p>
                     </div>
@@ -784,7 +779,7 @@ const AdminDashboard = () => {
                 {/* Documents Needed */}
                 {selectedCase.documents_needed && selectedCase.documents_needed.length > 0 && (
                   <div>
-                    <h4 className="font-semibold text-gray-900 mb-3">{language === 'en' ? 'Documents Needed' : 'Documentos Necesarios'}</h4>
+                    <h4 className="font-semibold text-gray-900 mb-3">{language === 'es' ? 'Documentos Necesarios' : 'Documents Needed'}</h4>
                     <div className="space-y-2">
                       {selectedCase.documents_needed.map((doc, index) => (
                         <div key={index} className="bg-green-50 border border-green-200 rounded px-3 py-2">
@@ -802,7 +797,7 @@ const AdminDashboard = () => {
                     className="w-full flex items-center justify-center px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
                   >
                     <Eye className="w-4 h-4 mr-2" />
-                    {language === 'en' ? 'View Case Summary' : 'Ver Resumen del Caso'}
+                    {language === 'es' ? 'Ver Resumen del Caso' : 'View Case Summary'}
                   </button>
 
                   {selectedCase.user_email && (
@@ -813,8 +808,8 @@ const AdminDashboard = () => {
                     >
                       <Send className="w-4 h-4 mr-2" />
                       {sendingEmail 
-                        ? (language === 'en' ? 'Sending...' : 'Enviando...')
-                        : (language === 'en' ? 'Send Email Summary' : 'Enviar Resumen por Correo')
+                        ? (language === 'es' ? 'Enviando...' : 'Sending...')
+                        : (language === 'es' ? 'Enviar Resumen por Correo' : 'Send Email Summary')
                       }
                     </button>
                   )}
@@ -824,7 +819,7 @@ const AdminDashboard = () => {
                     className="w-full flex items-center justify-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
                   >
                     <CheckCircle className="w-4 h-4 mr-2" />
-                    {language === 'en' ? 'Complete Case' : 'Completar Caso'}
+                    {language === 'es' ? 'Completar Caso' : 'Complete Case'}
                   </button>
                   
                   <button
@@ -834,7 +829,7 @@ const AdminDashboard = () => {
                     }}
                     className="w-full px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
                   >
-                    {language === 'en' ? 'Clear Selection' : 'Limpiar Selección'}
+                    {language === 'es' ? 'Limpiar Selección' : 'Clear Selection'}
                   </button>
                 </div>
               </div>
@@ -842,7 +837,7 @@ const AdminDashboard = () => {
               <div className="bg-white rounded-lg shadow-md p-6">
                 <div className="text-center text-gray-500">
                   <FileText className="w-12 h-12 mx-auto mb-4 text-gray-300" />
-                  <p>{language === 'en' ? 'Select a case to view details' : 'Selecciona un caso para ver detalles'}</p>
+                  <p>{language === 'es' ? 'Selecciona un caso para ver detalles' : 'Select a case to view details'}</p>
                 </div>
               </div>
             )}
@@ -867,7 +862,7 @@ const AdminDashboard = () => {
             {/* Modal Header */}
             <div className="flex items-center justify-between p-6 border-b border-gray-200">
               <h2 className="text-2xl font-bold text-gray-900">
-                {language === 'en' ? 'Case Summary' : 'Resumen del Caso'}
+                {language === 'es' ? 'Resumen del Caso' : 'Case Summary'}
               </h2>
               <button
                 onClick={() => setShowCaseSummaryModal(false)}
@@ -893,13 +888,13 @@ const AdminDashboard = () => {
                         {getPriorityLabel(caseSummaryData.priority || caseSummaryData.priority_level)[language]}
                       </h3>
                       <p className="text-gray-600">
-                        {language === 'en' ? 'Priority' : 'Prioridad'} {caseSummaryData.priority || caseSummaryData.priority_level}
+                        {language === 'es' ? 'Prioridad' : 'Priority'} {caseSummaryData.priority || caseSummaryData.priority_level}
                       </p>
                     </div>
                   </div>
                   <div className="text-right">
                     <p className="text-sm text-gray-500">
-                      {language === 'en' ? 'Status' : 'Estado'}
+                      {language === 'es' ? 'Estado' : 'Status'}
                     </p>
                     <p className="font-medium capitalize">
                       {caseSummaryData.status}
@@ -912,7 +907,7 @@ const AdminDashboard = () => {
               {(caseSummaryData.user_name || caseSummaryData.user_email || caseSummaryData.phone_number) && (
                 <div>
                   <h4 className="text-lg font-semibold text-gray-900 mb-3">
-                    {language === 'en' ? 'User Information' : 'Información del Usuario'}
+                    {language === 'es' ? 'Información del Usuario' : 'User Information'}
                   </h4>
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     {caseSummaryData.user_name && (
@@ -920,7 +915,7 @@ const AdminDashboard = () => {
                         <Users className="w-5 h-5 text-blue-600 mr-3" />
                         <div>
                           <p className="text-sm text-gray-500">
-                            {language === 'en' ? 'Name' : 'Nombre'}
+                            {language === 'es' ? 'Nombre' : 'Name'}
                           </p>
                           <p className="font-medium">{caseSummaryData.user_name}</p>
                         </div>
@@ -931,7 +926,7 @@ const AdminDashboard = () => {
                         <Mail className="w-5 h-5 text-green-600 mr-3" />
                         <div>
                           <p className="text-sm text-gray-500">
-                            {language === 'en' ? 'Email' : 'Correo'}
+                            {language === 'es' ? 'Correo' : 'Email'}
                           </p>
                           <p className="font-medium">{caseSummaryData.user_email}</p>
                         </div>
@@ -942,7 +937,7 @@ const AdminDashboard = () => {
                         <Phone className="w-5 h-5 text-purple-600 mr-3" />
                         <div>
                           <p className="text-sm text-gray-500">
-                            {language === 'en' ? 'Phone' : 'Teléfono'}
+                            {language === 'es' ? 'Teléfono' : 'Phone'}
                           </p>
                           <p className="font-medium">{caseSummaryData.phone_number}</p>
                         </div>
@@ -955,12 +950,12 @@ const AdminDashboard = () => {
               {/* Case Details */}
               <div>
                 <h4 className="text-lg font-semibold text-gray-900 mb-3">
-                  {language === 'en' ? 'Case Details' : 'Detalles del Caso'}
+                  {language === 'es' ? 'Detalles del Caso' : 'Case Details'}
                 </h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="p-4 bg-gray-50 rounded-lg">
                     <p className="text-sm text-gray-500">
-                      {language === 'en' ? 'Case Type' : 'Tipo de Caso'}
+                      {language === 'es' ? 'Tipo de Caso' : 'Case Type'}
                     </p>
                     <p className="font-medium">
                       {caseSummaryData.case_type || getPriorityLabel(caseSummaryData.priority || caseSummaryData.priority_level)[language]}
@@ -968,7 +963,7 @@ const AdminDashboard = () => {
                   </div>
                   <div className="p-4 bg-gray-50 rounded-lg">
                     <p className="text-sm text-gray-500">
-                      {language === 'en' ? 'Language' : 'Idioma'}
+                      {language === 'es' ? 'Idioma' : 'Language'}
                     </p>
                     <p className="font-medium uppercase">
                       {caseSummaryData.language || 'en'}
@@ -976,7 +971,7 @@ const AdminDashboard = () => {
                   </div>
                   <div className="p-4 bg-gray-50 rounded-lg">
                     <p className="text-sm text-gray-500">
-                      {language === 'en' ? 'Wait Time' : 'Tiempo de Espera'}
+                      {language === 'es' ? 'Tiempo de Espera' : 'Wait Time'}
                     </p>
                     <p className="font-medium">
                       {calculateWaitTime(caseSummaryData.arrived_at || caseSummaryData.timestamp || caseSummaryData.created_at)}
@@ -984,7 +979,7 @@ const AdminDashboard = () => {
                   </div>
                   <div className="p-4 bg-gray-50 rounded-lg">
                     <p className="text-sm text-gray-500">
-                      {language === 'en' ? 'Arrived At' : 'Llegó a las'}
+                      {language === 'es' ? 'Llegó a las' : 'Arrived At'}
                     </p>
                     <p className="font-medium">
                       {caseSummaryData.arrived_at || caseSummaryData.timestamp || caseSummaryData.created_at 
@@ -1000,7 +995,7 @@ const AdminDashboard = () => {
               {caseSummaryData.conversation_summary && (
                 <div>
                   <h4 className="text-lg font-semibold text-gray-900 mb-3">
-                    {language === 'en' ? 'Conversation Summary' : 'Resumen de Conversación'}
+                    {language === 'es' ? 'Resumen de Conversación' : 'Conversation Summary'}
                   </h4>
                   <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
                     <p className="text-gray-700 whitespace-pre-wrap">
@@ -1014,7 +1009,7 @@ const AdminDashboard = () => {
               {caseSummaryData.current_node && (
                 <div>
                   <h4 className="text-lg font-semibold text-gray-900 mb-3">
-                    {language === 'en' ? 'Current Step' : 'Paso Actual'}
+                    {language === 'es' ? 'Paso Actual' : 'Current Step'}
                   </h4>
                   <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
                     <p className="text-gray-700">{caseSummaryData.current_node}</p>
@@ -1026,7 +1021,7 @@ const AdminDashboard = () => {
               {caseSummaryData.documents_needed && caseSummaryData.documents_needed.length > 0 && (
                 <div>
                   <h4 className="text-lg font-semibold text-gray-900 mb-3">
-                    {language === 'en' ? 'Documents Needed' : 'Documentos Necesarios'}
+                    {language === 'es' ? 'Documentos Necesarios' : 'Documents Needed'}
                   </h4>
                   <div className="space-y-2">
                     {caseSummaryData.documents_needed.map((doc, index) => (
@@ -1042,7 +1037,7 @@ const AdminDashboard = () => {
               {caseSummaryData.next_steps && caseSummaryData.next_steps.length > 0 && (
                 <div>
                   <h4 className="text-lg font-semibold text-gray-900 mb-3">
-                    {language === 'en' ? 'Next Steps' : 'Próximos Pasos'}
+                    {language === 'es' ? 'Próximos Pasos' : 'Next Steps'}
                   </h4>
                   <div className="space-y-2">
                     {caseSummaryData.next_steps.map((step, index) => (
@@ -1058,7 +1053,7 @@ const AdminDashboard = () => {
               {caseSummaryData.answers && Object.keys(caseSummaryData.answers).length > 0 && (
                 <div>
                   <h4 className="text-lg font-semibold text-gray-900 mb-3">
-                    {language === 'en' ? 'Case Answers' : 'Respuestas del Caso'}
+                    {language === 'es' ? 'Respuestas del Caso' : 'Case Answers'}
                   </h4>
                   <div className="bg-gray-50 rounded-lg p-4">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -1079,7 +1074,7 @@ const AdminDashboard = () => {
               {caseSummaryData.history && caseSummaryData.history.length > 0 && (
                 <div>
                   <h4 className="text-lg font-semibold text-gray-900 mb-3">
-                    {language === 'en' ? 'Case History' : 'Historial del Caso'}
+                    {language === 'es' ? 'Historial del Caso' : 'Case History'}
                   </h4>
                   <div className="space-y-2">
                     {caseSummaryData.history.map((item, index) => (
@@ -1098,7 +1093,7 @@ const AdminDashboard = () => {
                 onClick={() => setShowCaseSummaryModal(false)}
                 className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
               >
-                {language === 'en' ? 'Close' : 'Cerrar'}
+                {language === 'es' ? 'Cerrar' : 'Close'}
               </button>
               {caseSummaryData.user_email && (
                 <button
@@ -1110,7 +1105,7 @@ const AdminDashboard = () => {
                   className="flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
                   <Send className="w-4 h-4 mr-2" />
-                  {language === 'en' ? 'Send Email' : 'Enviar Correo'}
+                  {language === 'es' ? 'Enviar Correo' : 'Send Email'}
                 </button>
               )}
             </div>

--- a/court-kiosk/frontend/src/pages/DVROPage.jsx
+++ b/court-kiosk/frontend/src/pages/DVROPage.jsx
@@ -1,19 +1,23 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useNavigate } from 'react-router-dom';
 import SimpleFlowRunner from '../components/SimpleFlowRunner';
 import { Shield, Home } from 'lucide-react';
+import LanguageSelector from '../components/LanguageSelector';
 
 const API_BASE_URL =
   process.env.REACT_APP_API_URL ||
   'http://localhost:4000';
 
 export default function DVROPage() {
-  const { language, toggleLanguage } = useLanguage();
+  const { language, t } = useLanguage();
   const navigate = useNavigate();
   const [showFlow, setShowFlow] = useState(false);
   const [flowData, setFlowData] = useState(null);
   const [loading, setLoading] = useState(true);
+
+  const quickInfoCards = useMemo(() => t('dvro.quickInfo') || [], [t]);
+  const whyCards = useMemo(() => t('dvro.whyCards') || [], [t]);
 
   useEffect(() => {
     fetch('/data/dv_flow_combined.json')
@@ -140,7 +144,7 @@ export default function DVROPage() {
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading application...</p>
+          <p className="text-gray-600">{t('dvro.loading')}</p>
         </div>
       </div>
     );
@@ -151,12 +155,12 @@ export default function DVROPage() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <p className="text-red-600">Failed to load application data</p>
+          <p className="text-red-600">{t('dvro.loadError')}</p>
           <button
             onClick={() => window.location.reload()}
             className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
           >
-            Try Again
+            {t('dvro.tryAgain')}
           </button>
         </div>
       </div>
@@ -187,7 +191,7 @@ export default function DVROPage() {
               className="flex items-center text-gray-600 hover:text-gray-800 transition-colors font-medium"
             >
               <Home className="w-5 h-5 mr-2" />
-              Back to Home
+              {t('dvro.backToHome')}
             </button>
 
             <div className="flex items-center space-x-6">
@@ -195,15 +199,10 @@ export default function DVROPage() {
                 <div className="w-8 h-8 bg-red-500 rounded-full flex items-center justify-center">
                   <Shield className="w-4 h-4 text-white" />
                 </div>
-                <span className="font-semibold text-gray-900">Family Court Clinic</span>
+                <span className="font-semibold text-gray-900">{t('dvro.clinicName')}</span>
               </div>
 
-              <button
-                onClick={toggleLanguage}
-                className="px-3 py-1 bg-blue-50 text-blue-700 rounded text-sm hover:bg-blue-100 transition-colors"
-              >
-                {language === 'es' ? 'EN' : 'ES'}
-              </button>
+              <LanguageSelector size="sm" />
             </div>
           </div>
         </div>
@@ -214,14 +213,11 @@ export default function DVROPage() {
         {/* Hero Section - Wider and More Prominent */}
         <div className="text-center mb-16">
           <h1 className="text-6xl font-bold text-gray-900 mb-6 leading-tight">
-            {language === 'es' ? 'Órdenes de Restricción' : 'Domestic Violence Restraining Orders'}
+            {t('dvro.heroTitle')}
           </h1>
 
           <p className="text-xl text-gray-600 mb-8 max-w-4xl mx-auto leading-relaxed">
-            {language === 'es'
-              ? 'Obtenga ayuda para solicitar una orden de restricción. Le guiaremos paso a paso con información y formularios específicos.'
-              : 'Get help applying for a restraining order. We\'ll guide you step by step with information and specific forms.'
-            }
+            {t('dvro.heroDescription')}
           </p>
         </div>
 
@@ -230,16 +226,8 @@ export default function DVROPage() {
           <div className="flex items-center space-x-3">
             <div className="w-3 h-3 bg-red-500 rounded-full"></div>
             <p className="text-red-800 text-base">
-              {language === 'es'
-                ? 'Si está en peligro inmediato, llame al 911. '
-                : 'If you are in immediate danger, call 911. '
-              }
-              <span className="font-medium">
-                {language === 'es'
-                  ? 'Ahora puede comenzar su solicitud.'
-                  : 'You can now begin your application.'
-                }
-              </span>
+              {t('dvro.emergencyNotice')}{' '}
+              <span className="font-medium">{t('dvro.emergencyAction')}</span>
             </p>
           </div>
         </div>
@@ -251,94 +239,45 @@ export default function DVROPage() {
             className="inline-flex items-center px-12 py-6 bg-red-600 text-white font-semibold text-lg rounded-lg hover:bg-red-700 transition-colors shadow-lg"
           >
             <Shield className="w-6 h-6 mr-3" />
-            {language === 'es' ? 'Comenzar Solicitud' : 'Start Application'}
+            {t('dvro.startApplication')}
           </button>
 
           <p className="text-base text-gray-500 mt-4">
-            {language === 'es'
-              ? 'Gratis y confidencial • 15-20 minutos'
-              : 'Free and confidential • 15-20 minutes'
-            }
+            {t('dvro.startDetails')}
           </p>
         </div>
 
         {/* Quick Info - Wider Grid */}
         <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
-          <div className="bg-white rounded-xl p-8 shadow-lg border border-gray-100">
-            <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <span className="text-blue-600 font-bold text-lg">1</span>
+          {quickInfoCards.map((card, index) => (
+            <div key={card.title} className="bg-white rounded-xl p-8 shadow-lg border border-gray-100">
+              <div className="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-4"
+                style={{ backgroundColor: ['#DBEAFE', '#DCFCE7', '#EDE9FE'][index % 3], color: ['#2563EB', '#16A34A', '#7C3AED'][index % 3] }}>
+                <span className="font-bold text-lg">{index + 1}</span>
+              </div>
+              <h3 className="text-xl font-semibold text-gray-900 mb-3 text-center">
+                {card.title}
+              </h3>
+              <p className="text-gray-600 text-center leading-relaxed">
+                {card.description}
+              </p>
             </div>
-            <h3 className="text-xl font-semibold text-gray-900 mb-3 text-center">
-              {language === 'es' ? 'Información' : 'Information'}
-            </h3>
-            <p className="text-gray-600 text-center leading-relaxed">
-              {language === 'es'
-                ? 'Aprenda sobre el proceso legal, sus derechos y las opciones disponibles para su situación específica.'
-                : 'Learn about the legal process, your rights, and the options available for your specific situation.'
-              }
-            </p>
-          </div>
-
-          <div className="bg-white rounded-xl p-8 shadow-lg border border-gray-100">
-            <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <span className="text-green-600 font-bold text-lg">2</span>
-            </div>
-            <h3 className="text-xl font-semibold text-gray-900 mb-3 text-center">
-              {language === 'es' ? 'Preguntas' : 'Questions'}
-            </h3>
-            <p className="text-gray-600 text-center leading-relaxed">
-              {language === 'es'
-                ? 'Responda preguntas simples sobre su situación para recibir orientación personalizada y específica.'
-                : 'Answer simple questions about your situation to receive personalized and specific guidance.'
-              }
-            </p>
-          </div>
-
-          <div className="bg-white rounded-xl p-8 shadow-lg border border-gray-100">
-            <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <span className="text-purple-600 font-bold text-lg">3</span>
-            </div>
-            <h3 className="text-xl font-semibold text-gray-900 mb-3 text-center">
-              {language === 'es' ? 'Formularios' : 'Forms'}
-            </h3>
-            <p className="text-gray-600 text-center leading-relaxed">
-              {language === 'es'
-                ? 'Obtenga los formularios específicos que necesita para su caso, con instrucciones detalladas.'
-                : 'Get the specific forms you need for your case, with detailed instructions.'
-              }
-            </p>
-          </div>
+          ))}
         </div>
 
         {/* Additional Information Section */}
         <div className="mt-20 max-w-5xl mx-auto">
           <div className="bg-white rounded-xl p-8 shadow-lg border border-gray-100">
             <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-              {language === 'es' ? '¿Por qué usar este sistema?' : 'Why use this system?'}
+              {t('dvro.whyTitle')}
             </h2>
             <div className="grid md:grid-cols-2 gap-8">
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-3">
-                  {language === 'es' ? 'Información Completa' : 'Complete Information'}
-                </h3>
-                <p className="text-gray-600 leading-relaxed">
-                  {language === 'es'
-                    ? 'Cada pregunta incluye información contextual para que comprenda completamente antes de tomar decisiones.'
-                    : 'Every question includes contextual information so you understand completely before making decisions.'
-                  }
-                </p>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-3">
-                  {language === 'es' ? 'Formularios Específicos' : 'Specific Forms'}
-                </h3>
-                <p className="text-gray-600 leading-relaxed">
-                  {language === 'es'
-                    ? 'Reciba solo los formularios que necesita para su situación específica, sin confusión.'
-                    : 'Receive only the forms you need for your specific situation, without confusion.'
-                  }
-                </p>
-              </div>
+              {whyCards.map((card) => (
+                <div key={card.title}>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-3">{card.title}</h3>
+                  <p className="text-gray-600 leading-relaxed">{card.description}</p>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/court-kiosk/frontend/src/pages/DivorcePage.jsx
+++ b/court-kiosk/frontend/src/pages/DivorcePage.jsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Shield, Clock, Home } from 'lucide-react';
+import LanguageSelector from '../components/LanguageSelector';
 
 const DivorcePage = () => {
-  const { language, toggleLanguage } = useLanguage();
+  const { t } = useLanguage();
   const navigate = useNavigate();
+
+  const learningTopics = useMemo(() => t('divorce.learnCards') || [], [t]);
+  const importantNotes = useMemo(() => t('divorce.notes') || [], [t]);
 
   const handleStartApplication = () => {
     navigate('/divorce-flow');
@@ -26,23 +30,18 @@ const DivorcePage = () => {
               className="flex items-center text-gray-600 hover:text-gray-900 transition-colors"
             >
               <Home className="w-4 h-4 mr-2" />
-              Back to Home
+              {t('divorce.backToHome')}
             </button>
-            
+
             <div className="flex items-center space-x-6">
               <div className="flex items-center space-x-3">
                 <div className="w-8 h-8 bg-yellow-500 rounded-full flex items-center justify-center">
                   <Shield className="w-4 h-4 text-white" />
                 </div>
-                <span className="font-semibold text-gray-900">Family Court Clinic</span>
+                <span className="font-semibold text-gray-900">{t('divorce.clinicName')}</span>
               </div>
 
-              <button
-                onClick={toggleLanguage}
-                className="px-3 py-1 bg-blue-50 text-blue-700 rounded text-sm hover:bg-blue-100 transition-colors"
-              >
-                {language === 'es' ? 'EN' : 'ES'}
-              </button>
+              <LanguageSelector size="sm" />
             </div>
           </div>
         </div>
@@ -53,13 +52,12 @@ const DivorcePage = () => {
         <div className="text-center">
           {/* Title */}
           <h1 className="text-6xl font-bold text-gray-900 mb-6">
-            Divorce & Legal Separation
+            {t('divorce.heroTitle')}
           </h1>
-          
+
           {/* Description */}
           <p className="text-xl text-gray-600 mb-8 max-w-3xl mx-auto">
-            Get help with divorce proceedings, legal separation, and property division. 
-            We'll guide you step by step with information and specific forms needed for your case.
+            {t('divorce.heroDescription')}
           </p>
 
           {/* Information Box */}
@@ -68,8 +66,7 @@ const DivorcePage = () => {
               <div className="w-3 h-3 bg-blue-500 rounded-full mt-2 mr-3 flex-shrink-0"></div>
               <div className="text-left">
                 <p className="text-blue-800 font-medium">
-                  Understanding your rights and the divorce process is crucial. 
-                  This guide will help you navigate the legal requirements and prepare the necessary documentation.
+                  {t('divorce.infoBanner')}
                 </p>
               </div>
             </div>
@@ -81,7 +78,7 @@ const DivorcePage = () => {
             className="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-6 px-8 rounded-lg text-lg transition-colors duration-200 flex items-center mx-auto mb-6"
           >
             <Shield className="w-6 h-6 mr-3" />
-            Start Divorce Guide
+            {t('divorce.startGuide')}
           </button>
 
           {/* Additional Information */}
@@ -89,12 +86,8 @@ const DivorcePage = () => {
             <div className="flex items-center justify-center space-x-6">
               <span className="flex items-center">
                 <Clock className="w-4 h-4 mr-1" />
-                Free and confidential
+                {t('divorce.startDetails')}
               </span>
-              <span>•</span>
-              <span>20-30 minutes</span>
-              <span>•</span>
-              <span>Step-by-step guidance</span>
             </div>
           </div>
         </div>
@@ -102,48 +95,26 @@ const DivorcePage = () => {
         {/* What You'll Learn Section */}
         <div className="mt-16">
           <h2 className="text-2xl font-semibold text-gray-900 text-center mb-8">
-            What You'll Learn
+            {t('divorce.learnTitle')}
           </h2>
-          
+
           <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
-            <div className="bg-gray-50 rounded-lg p-6">
-              <h3 className="font-semibold text-gray-900 mb-3">Residency Requirements</h3>
-              <p className="text-gray-600">
-                Understand California's residency requirements and eligibility for filing divorce proceedings.
-              </p>
-            </div>
-            
-            <div className="bg-gray-50 rounded-lg p-6">
-              <h3 className="font-semibold text-gray-900 mb-3">Required Forms</h3>
-              <p className="text-gray-600">
-                Learn about essential forms like FL-100 (Petition), FL-110 (Summons), and child custody forms if applicable.
-              </p>
-            </div>
-            
-            <div className="bg-gray-50 rounded-lg p-6">
-              <h3 className="font-semibold text-gray-900 mb-3">Service Requirements</h3>
-              <p className="text-gray-600">
-                Understand how to properly serve divorce papers to your spouse within the required timeframe.
-              </p>
-            </div>
-            
-            <div className="bg-gray-50 rounded-lg p-6">
-              <h3 className="font-semibold text-gray-900 mb-3">Next Steps</h3>
-              <p className="text-gray-600">
-                Get guidance on what happens after filing, including response periods and court procedures.
-              </p>
-            </div>
+            {learningTopics.map((topic) => (
+              <div key={topic.title} className="bg-gray-50 rounded-lg p-6">
+                <h3 className="font-semibold text-gray-900 mb-3">{topic.title}</h3>
+                <p className="text-gray-600">{topic.description}</p>
+              </div>
+            ))}
           </div>
         </div>
 
         {/* Important Notes */}
         <div className="mt-12 bg-yellow-50 border border-yellow-200 rounded-lg p-6">
-          <h3 className="font-semibold text-yellow-800 mb-3">Important Information</h3>
+          <h3 className="font-semibold text-yellow-800 mb-3">{t('divorce.notesTitle')}</h3>
           <ul className="text-yellow-700 text-sm space-y-2">
-            <li>• This guide provides general information and is not legal advice</li>
-            <li>• For complex cases or legal advice, consult with an attorney</li>
-            <li>• Court staff can help with procedural questions but cannot provide legal advice</li>
-            <li>• All forms and procedures must comply with California family law requirements</li>
+            {importantNotes.map((note, index) => (
+              <li key={index}>• {note}</li>
+            ))}
           </ul>
         </div>
       </div>

--- a/court-kiosk/frontend/src/pages/ExperimentIndex.jsx
+++ b/court-kiosk/frontend/src/pages/ExperimentIndex.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Shield, Heart, FileText, Users, Sparkles } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
@@ -6,59 +6,54 @@ import ModernCourtHeader from '../components/ModernCourtHeader';
 import ModernCaseTypeCard from '../components/ModernCaseTypeCard';
 import '../components/ExperimentUI.css';
 
-const caseTypes = [
+const CASE_TYPES = [
   {
-    title: { en: "Domestic Violence", es: "Violencia Doméstica" },
-    description: { 
-      en: "Restraining orders, protection orders, emergency cases. Immediate assistance for safety and legal protection.",
-      es: "Órdenes de restricción, órdenes de protección, casos de emergencia. Asistencia inmediata para seguridad y protección legal."
-    },
+    key: 'dvro',
     icon: Shield,
-    priority: "PRIORITY A",
-    colorScheme: "domestic-violence",
-    path: "/dvro",
+    colorScheme: 'domestic-violence',
+    path: '/dvro'
   },
   {
-    title: { en: "Child Custody & Support", es: "Custodia y Manutención" },
-    description: { 
-      en: "Child custody arrangements, support calculations, and visitation rights. Protecting children's best interests.",
-      es: "Arreglos de custodia de menores, cálculos de manutención y derechos de visita. Protegiendo el mejor interés de los niños."
-    },
+    key: 'custody',
     icon: Heart,
-    priority: "PRIORITY B",
-    colorScheme: "child-custody",
-    path: "/custody",
+    colorScheme: 'child-custody',
+    path: '/',
+    preselect: 'B'
   },
   {
-    title: { en: "Divorce & Separation", es: "Divorcio y Separación" },
-    description: { 
-      en: "Divorce proceedings, legal separation, serving papers, and next steps. Guided process for life transitions.",
-      es: "Procedimientos de divorcio, separación legal, entrega de documentos y próximos pasos. Proceso guiado para transiciones de vida."
-    },
+    key: 'divorce',
     icon: FileText,
-    priority: "PRIORITY C",
-    colorScheme: "divorce",
-    path: "/divorce",
+    colorScheme: 'divorce',
+    path: '/divorce'
   },
   {
-    title: { en: "Other Family Law", es: "Otro Derecho de Familia" },
-    description: { 
-      en: "Parentage, guardianship, name changes, adoption, and other family legal matters. Comprehensive support.",
-      es: "Paternidad, tutela, cambios de nombre, adopción y otros asuntos legales familiares. Apoyo integral."
-    },
+    key: 'other',
     icon: Users,
-    priority: "PRIORITY D",
-    colorScheme: "other-family",
-    path: "/other",
-  },
+    colorScheme: 'other-family',
+    path: '/',
+    preselect: 'D'
+  }
 ];
 
 const ExperimentIndex = () => {
   const navigate = useNavigate();
-  const { language, toggleLanguage } = useLanguage();
+  const { t } = useLanguage();
 
-  const handleCaseTypeClick = (path) => {
-    navigate(path);
+  const localizedCaseTypes = useMemo(() => (
+    CASE_TYPES.map((caseType) => ({
+      ...caseType,
+      title: t(`experiment.caseTypes.${caseType.key}.title`),
+      description: t(`experiment.caseTypes.${caseType.key}.description`),
+      priority: t(`experiment.caseTypes.${caseType.key}.priority`)
+    }))
+  ), [t]);
+
+  const handleCaseTypeClick = (caseType) => {
+    if (caseType.preselect) {
+      navigate(caseType.path, { state: { preselectCaseId: caseType.preselect } });
+      return;
+    }
+    navigate(caseType.path);
   };
 
   return (
@@ -69,49 +64,46 @@ const ExperimentIndex = () => {
         <div className="absolute bottom-20 right-20 w-80 h-80 bg-other-family/5 rounded-full blur-3xl animate-float" style={{ animationDelay: '1s' }}></div>
         <div className="absolute top-1/2 left-1/2 w-64 h-64 bg-divorce/5 rounded-full blur-3xl animate-float" style={{ animationDelay: '2s' }}></div>
       </div>
-      
-      <ModernCourtHeader onLanguageToggle={toggleLanguage} currentLanguage={language} />
-      
+
+      <ModernCourtHeader />
+
       <main className="relative max-w-7xl mx-auto px-6 lg:px-8 py-16">
         {/* Hero Section */}
         <div className="text-center mb-16 animate-fade-in">
           <div className="inline-flex items-center space-x-2 bg-primary/10 border border-primary/20 rounded-full px-4 py-2 mb-6">
             <Sparkles className="w-4 h-4 text-primary" />
             <span className="text-sm font-medium text-primary">
-              {language === 'en' ? 'Professional Legal Assistance' : 'Asistencia Legal Profesional'}
+              {t('experiment.heroTitle')}
             </span>
           </div>
-          
+
           <h1 className="text-5xl lg:text-6xl font-display font-bold text-foreground mb-6 leading-tight">
-            {language === 'en' ? 'Family Law' : 'Derecho de Familia'}
+            {t('experiment.heroSubtitle')}
             <span className="block bg-gradient-to-r from-primary via-primary to-other-family bg-clip-text text-transparent">
-              {language === 'en' ? 'Self-Help Kiosk' : 'Quiosco de Autoayuda'}
+              {t('experiment.heroTagline')}
             </span>
           </h1>
-          
+
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed mb-4">
-            {language === 'en' ? 'Select Your Case Type to Begin' : 'Seleccione su Tipo de Caso para Comenzar'}
+            {t('experiment.intro')}
           </p>
-          
+
           <p className="text-muted-foreground max-w-2xl mx-auto">
-            {language === 'en' 
-              ? 'Choose the option that best describes your legal need. Our guided system will walk you through each step with clear instructions and professional support.'
-              : 'Elija la opción que mejor describa su necesidad legal. Nuestro sistema guiado lo llevará a través de cada paso con instrucciones claras y apoyo profesional.'
-            }
+            {t('experiment.description')}
           </p>
         </div>
 
         {/* Case Type Cards */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 max-w-6xl mx-auto mb-16">
-          {caseTypes.map((caseType, index) => (
+          {localizedCaseTypes.map((caseType, index) => (
             <ModernCaseTypeCard
-              key={caseType.title[language]}
-              title={caseType.title[language]}
-              description={caseType.description[language]}
+              key={caseType.key}
+              title={caseType.title}
+              description={caseType.description}
               icon={caseType.icon}
               priority={caseType.priority}
               colorScheme={caseType.colorScheme}
-              onClick={() => handleCaseTypeClick(caseType.path)}
+              onClick={() => handleCaseTypeClick(caseType)}
               index={index}
             />
           ))}
@@ -125,13 +117,10 @@ const ExperimentIndex = () => {
             
             <div className="relative p-8">
               <h3 className="font-display font-semibold text-foreground mb-3">
-                {language === 'en' ? 'Need Assistance?' : '¿Necesita Asistencia?'}
+                {t('experiment.supportTitle')}
               </h3>
               <p className="text-muted-foreground leading-relaxed">
-                {language === 'en' 
-                  ? 'Court staff are available to assist you with using this kiosk. Please visit the information desk if you need help navigating the system or have questions about your case.'
-                  : 'El personal del tribunal está disponible para ayudarlo con el uso de este quiosco. Por favor visite el mostrador de información si necesita ayuda navegando el sistema o tiene preguntas sobre su caso.'
-                }
+                {t('experiment.supportDescription')}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Introduced centralized translation resources and a reusable language selector so visitors can explicitly choose their preferred language across the kiosk.
- Localized navigation, headers, and the primary customer journeys (User Kiosk, DVRO, Divorce, Experiment index) with translated copy plus queue preselection when launching flows from the experiment screen.
- Updated administrative and attorney dashboards as well as the login form to fall back to English when additional languages are selected and to share the unified selector component.

## Testing
- npm test -- --watchAll=false *(fails: react-scripts is not installed in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e327bfc6d883339719fea137e31024