### PR TITLE
Improve kiosk categories and form download reliability

### DIFF
--- a/court-kiosk/frontend/src/pages/UserKiosk.jsx
+++ b/court-kiosk/frontend/src/pages/UserKiosk.jsx
@@ -38,61 +38,49 @@ const UserKiosk = () => {
 
   const caseTypes = [
     {
-      id: 'A',
+      id: 'DV',
       priority: 'A',
       case_type: 'DVRO',
       title: { en: 'Domestic Violence', es: 'Violencia Doméstica' },
-      description: { 
-        en: 'Restraining orders, protection orders, emergency cases.', 
-        es: 'Órdenes de restricción, órdenes de protección, casos de emergencia.' 
+      description: {
+        en: 'Domestic violence restraining orders, safety planning, emergency help.',
+        es: 'Órdenes de restricción por violencia doméstica, planificación de seguridad, ayuda de emergencia.'
       },
       icon: Shield,
       accent: 'bg-red-50'
     },
     {
-      id: 'B',
+      id: 'DIV',
       priority: 'B',
-      case_type: 'CHRO',
-      title: { en: 'Civil Harassment', es: 'Acoso Civil' },
-      description: { 
-        en: 'Civil harassment restraining orders for neighbors, coworkers, strangers.', 
-        es: 'Órdenes de restricción por acoso civil para vecinos, compañeros de trabajo, extraños.' 
-      },
-      icon: AlertTriangle,
-      accent: 'bg-orange-50'
-    },
-    {
-      id: 'C',
-      priority: 'C',
-      case_type: 'CUSTODY',
-      title: { en: 'Child Custody & Support', es: 'Custodia y Manutención' },
-      description: { 
-        en: 'Child custody, support, visitation rights.', 
-        es: 'Custodia de menores, manutención infantil, derechos de visita.' 
-      },
-      icon: HeartHandshake,
-      accent: 'bg-amber-50'
-    },
-    {
-      id: 'D',
-      priority: 'D',
       case_type: 'DIVORCE',
       title: { en: 'Divorce & Separation', es: 'Divorcio y Separación' },
-      description: { 
-        en: 'Divorce, legal separation, serving papers, next steps.', 
-        es: 'Divorcio, separación legal, entrega de documentos, próximos pasos.' 
+      description: {
+        en: 'Divorce, legal separation, serving papers, and financial disclosures.',
+        es: 'Divorcio, separación legal, entrega de documentos y declaraciones financieras.'
       },
       icon: FileText,
       accent: 'bg-blue-50'
     },
     {
-      id: 'E',
-      priority: 'E',
+      id: 'CUST',
+      priority: 'C',
+      case_type: 'CUSTODY',
+      title: { en: 'Child Custody & Support', es: 'Custodia y Manutención' },
+      description: {
+        en: 'Child custody, visitation, support, and safety concerns.',
+        es: 'Custodia de menores, visitas, manutención y preocupaciones de seguridad.'
+      },
+      icon: HeartHandshake,
+      accent: 'bg-amber-50'
+    },
+    {
+      id: 'OTHER',
+      priority: 'D',
       case_type: 'OTHER',
-      title: { en: 'Other Family Law', es: 'Otro Derecho de Familia' },
-      description: { 
-        en: 'Parentage, guardianship, name change, and more.', 
-        es: 'Paternidad, tutela, cambio de nombre y más.' 
+      title: { en: 'Other Family Court Issues', es: 'Otros Asuntos de la Corte de Familia' },
+      description: {
+        en: 'Civil Harassment (neighbors/strangers), elder abuse, parentage, guardianship, name change, fee waivers.',
+        es: 'Acoso civil (vecinos/desconocidos), abuso a mayores, paternidad, tutela, cambio de nombre, exenciones de tarifas.'
       },
       icon: Users,
       accent: 'bg-emerald-50'
@@ -104,21 +92,27 @@ const UserKiosk = () => {
     setIsProcessing(true);
 
     try {
-      // For Domestic Violence cases (Priority A), redirect to the comprehensive DVRO page
-      if (caseType.id === 'A') {
+      // For Domestic Violence cases, redirect to the comprehensive DVRO page
+      if (caseType.case_type === 'DVRO') {
         navigate('/dvro');
         return;
       }
 
-      // For Civil Harassment cases (Priority B), redirect to the CHRO page
-      if (caseType.id === 'B') {
-        navigate('/chro');
+      // For Divorce & Separation cases, redirect to the divorce page
+      if (caseType.case_type === 'DIVORCE') {
+        navigate('/divorce');
         return;
       }
 
-      // For Divorce & Separation cases (Priority D), redirect to the divorce flow runner
-      if (caseType.id === 'D') {
-        navigate('/divorce');
+      // For Child Custody cases, redirect to custody resources
+      if (caseType.case_type === 'CUSTODY') {
+        navigate('/custody');
+        return;
+      }
+
+      // For civil harassment and other family law issues, show the extended options page
+      if (caseType.case_type === 'OTHER') {
+        navigate('/other');
         return;
       }
 
@@ -320,6 +314,33 @@ const UserKiosk = () => {
             <Tile key={caseType.id} caseType={caseType} />
           ))}
         </div>
+      </div>
+
+      {/* Highlight the civil harassment pilot flow while keeping four core categories */}
+      <div className="mx-auto max-w-5xl w-full px-4 pb-8">
+        <ModernCard variant="info" className="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+          <div>
+            <h3 className="text-2xl font-bold text-white mb-2">
+              {language === 'en'
+                ? 'Civil Harassment Restraining Order (for non-family members)'
+                : 'Orden de restricción por acoso civil (para personas sin relación familiar)'}
+            </h3>
+            <p className="text-white/90 text-lg font-medium">
+              {language === 'en'
+                ? 'Neighbors, coworkers, roommates, or strangers. Start the dedicated flow here so staff can implement it quickly.'
+                : 'Vecinos, compañeros de trabajo, compañeros de vivienda o desconocidos. Inicie el flujo dedicado aquí para que el personal pueda implementarlo rápidamente.'}
+            </p>
+          </div>
+          <ModernButton
+            variant="primary"
+            size="large"
+            onClick={() => navigate('/chro')}
+            icon={<ChevronRight className="w-5 h-5" />}
+            iconPosition="right"
+          >
+            {language === 'en' ? 'Start Civil Harassment' : 'Comenzar Acoso Civil'}
+          </ModernButton>
+        </ModernCard>
       </div>
 
       {/* Info Strip (keep only emergency; remove location/hours per feedback) */}

--- a/court-kiosk/frontend/src/utils/formUtils.js
+++ b/court-kiosk/frontend/src/utils/formUtils.js
@@ -2,6 +2,79 @@
  * Utility functions for handling court forms and hyperlinks
  */
 
+import { buildApiUrl } from './apiConfig';
+
+/**
+ * Map of locally bundled PDFs so links don't 404 and emails can attach them reliably
+ */
+const localFormFiles = {
+  // Domestic Violence
+  'DV-100': 'dv100.pdf',
+  'DV-101': 'dv101.pdf',
+  'DV-105': 'dv105.pdf',
+  'DV-105A': 'dv105a.pdf',
+  'DV-108': 'dv108.pdf',
+  'DV-109': 'dv109.pdf',
+  'DV-110': 'dv110.pdf',
+  'DV-112': 'dv112.pdf',
+  'DV-116': 'dv116.pdf',
+  'DV-120': 'dv120.pdf',
+  'DV-120INFO': 'dv120info.pdf',
+  'DV-125': 'dv125.pdf',
+  'DV-130': 'dv130.pdf',
+  'DV-140': 'dv140.pdf',
+  'DV-145': 'dv145.pdf',
+  'DV-200': 'dv200.pdf',
+  'DV-250': 'dv250.pdf',
+  'DV-700': 'dv700.pdf',
+  'DV-710': 'dv710.pdf',
+  'DV-720': 'dv720.pdf',
+  'DV-800': 'dv800.pdf',
+
+  // Civil Harassment
+  'CH-100': 'ch100.pdf',
+  'CH-109': 'ch109.pdf',
+  'CH-110': 'ch110.pdf',
+  'CH-120': 'ch120.pdf',
+  'CH-120-INFO': 'ch120info.pdf',
+  'CH-130': 'ch130.pdf',
+  'CH-200': 'ch200.pdf',
+  'CH-250': 'ch250.pdf',
+  'CH-700': 'ch700.pdf',
+  'CH-710': 'ch710.pdf',
+  'CH-720': 'ch720.pdf',
+  'CH-730': 'ch730.pdf',
+  'CH-800': 'ch800.pdf',
+
+  // Divorce / Family law
+  'FL-100': 'fl100.pdf',
+  'FL-105': 'fl105.pdf',
+  'FL-110': 'fl110.pdf',
+  'FL-115': 'fl115.pdf',
+  'FL-117': 'fl117.pdf',
+  'FL-120': 'fl120.pdf',
+  'FL-130': 'fl130.pdf',
+  'FL-140': 'fl140.pdf',
+  'FL-141': 'fl141.pdf',
+  'FL-142': 'fl142.pdf',
+  'FL-144': 'fl144.pdf',
+  'FL-150': 'fl150.pdf',
+
+  // Other frequently used forms
+  'CLETS-001': 'clets001.pdf',
+  'CM-010': 'cm010.pdf',
+  'MC-025': 'mc025.pdf',
+  'MC-031': 'mc031.pdf',
+  'MC-040': 'mc040.pdf',
+  'MC-050': 'mc050.pdf',
+  'POS-040': 'pos040.pdf',
+};
+
+const getLocalFormUrl = (normalized) => {
+  const fileName = localFormFiles[normalized];
+  return fileName ? buildApiUrl(`/api/documents/${fileName}`) : null;
+};
+
 /**
  * Get the URL for a court form
  * @param {string} formCode - The form code (e.g., 'DV-100', 'CLETS-001')
@@ -13,7 +86,12 @@ export function getFormUrl(formCode) {
   }
 
   const normalized = formCode.trim().toUpperCase();
-  
+
+  const localUrl = getLocalFormUrl(normalized);
+  if (localUrl) {
+    return localUrl;
+  }
+
   // Comprehensive mapping of all California Judicial Council forms
   // Using official California Courts website URLs
   const knownForms = {


### PR DESCRIPTION
## Summary
- streamline kiosk home screen into four primary categories and spotlight the civil harassment pilot flow
- route users to the correct flows for divorce, custody, and civil harassment while keeping other issues grouped together
- serve form links and email attachments from bundled PDFs to avoid broken links or missing attachments

## Testing
- npm test -- --watch=false *(fails: react-scripts not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6936f69d74008333bdc6689ccfb14f97)